### PR TITLE
fix: made remove branch on merge the default behaviour for GitLab merge

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -258,12 +258,14 @@ func (g *Gitlab) CreatePullRequest(ctx context.Context, repo domain.Repository, 
 		}
 	}
 
+	removeSourceBranch := true
 	mr, _, err := g.glClient.MergeRequests.CreateMergeRequest(r.pid, &gitlab.CreateMergeRequestOptions{
-		Title:        &newPR.Title,
-		Description:  &newPR.Body,
-		SourceBranch: &newPR.Head,
-		TargetBranch: &newPR.Base,
-		AssigneeIDs:  assigneeIDs,
+		Title:              &newPR.Title,
+		Description:        &newPR.Body,
+		SourceBranch:       &newPR.Head,
+		TargetBranch:       &newPR.Base,
+		AssigneeIDs:        assigneeIDs,
+		RemoveSourceBranch: &removeSourceBranch,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
requests