### PR TITLE
Config option pr title tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Flags:
   -p, --platform string         The platform that is used. Available values: github, gitlab, gitea. (default "github")
   -b, --pr-body string          The body of the commit message. Will default to everything but the first line of the commit message if none is set.
   -t, --pr-title string         The title of the PR. Will default to the first line of the commit message if none is set.
+      --pr-title-tags strings   A list of tags with which to prefix the pr-title (will render as '[tag1][tag2] {{pr-title}}')
   -P, --project strings         The name, including owner of a GitLab project in the format "ownerName/repoName".
   -R, --repo strings            The name, including owner of a GitHub repository in the format "ownerName/repoName".
   -r, --reviewers strings       The username of the reviewers to be added on the pull request.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ pr-body:
 # The title of the PR. Will default to the first line of the commit message if none is set.
 pr-title:
 
+# A list of tags with which to prefix the pr-title (will render as '[tag1][tag2] {{pr-title}}')
+pr-title-tags:
+  - example
+
 # The name, including owner of a GitLab project in the format "ownerName/repoName".
 project:
   - group/project

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -35,6 +35,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringP("branch", "B", "multi-gitter-branch", "The name of the branch where changes are committed.")
 	cmd.Flags().StringP("base-branch", "", "", "The branch which the changes will be based on.")
 	cmd.Flags().StringP("pr-title", "t", "", "The title of the PR. Will default to the first line of the commit message if none is set.")
+	cmd.Flags().StringSliceP("pr-title-tags", "", nil, "A list of tags with which to prefix the pr-title (will render as '[tag1][tag2] {{pr-title}}')")
 	cmd.Flags().StringP("pr-body", "b", "", "The body of the commit message. Will default to everything but the first line of the commit message if none is set.")
 	cmd.Flags().StringP("commit-message", "m", "", "The commit message. Will default to title + body if none is set.")
 	cmd.Flags().StringSliceP("reviewers", "r", nil, "The username of the reviewers to be added on the pull request.")
@@ -62,6 +63,7 @@ func run(cmd *cobra.Command, args []string) error {
 	branchName, _ := flag.GetString("branch")
 	baseBranchName, _ := flag.GetString("base-branch")
 	prTitle, _ := flag.GetString("pr-title")
+	prTitleTags, _ := flag.GetStringSlice("pr-title-tags")
 	prBody, _ := flag.GetString("pr-body")
 	commitMessage, _ := flag.GetString("commit-message")
 	reviewers, _ := flag.GetStringSlice("reviewers")
@@ -104,6 +106,11 @@ func run(cmd *cobra.Command, args []string) error {
 		if prBody == "" && len(split) == 2 {
 			prBody = split[2]
 		}
+	}
+
+	if len(prTitleTags) > 0 {
+		// eg: '[tag1][tag2] my PR!'
+		prTitle = fmt.Sprintf("[%s] %s", strings.Join(prTitleTags, "]["), prTitle)
 	}
 
 	if skipPullRequest && forkMode {

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -655,7 +655,7 @@ Repositories with a successful run:
 				require.Len(t, vcMock.PullRequests, 1)
 				assert.Equal(t, "custom-branch-name", vcMock.PullRequests[0].Head)
 				assert.Equal(t, "master", vcMock.PullRequests[0].Base)
-				assert.Equal(t, "config-message", vcMock.PullRequests[0].Title)
+				assert.Equal(t, "[tag1][tag2] config-message", vcMock.PullRequests[0].Title)
 
 				assert.Equal(t, `Repositories with a successful run:
   owner/should-change #1

--- a/tests/test-config.yaml
+++ b/tests/test-config.yaml
@@ -1,2 +1,5 @@
 branch: should-not-be-used
 commit-message: config-message
+pr-title-tags:
+  - tag1
+  - tag2


### PR DESCRIPTION
# What does this change

Config option pr-title-tags

A list of tags to prefix a pr-title.

# What issue does it fix

Use case: I'd like to be able to filter PRs created by this tool out of
my email inbox. I can do that by having my team's config contain:
```yaml
pr-title-tags:
  - automated-pr
```

# Notes for the reviewer
`TestPrint` fails for me locally on two asserts (`"i like apples\ni like my apple\ni like oranges\n"` and `"I LIKE APPLES\nI LIKE MY APPLE\nI LIKE ORANGES\n"`), but these also fail on head of master, so I suspect this is a local issue and :crossed_fingers: won't happen in CI.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
