### PR TITLE
feat: added --conflict-strategy

### DIFF
--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -45,7 +45,10 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
 	cmd.Flags().BoolP("interactive", "i", false, "Take manual decision before committing any change. Requires git to be installed.")
 	cmd.Flags().BoolP("dry-run", "d", false, "Run without pushing changes or creating pull requests.")
-	cmd.Flags().StringP("conflict-strategy", "", "skip", "What should happen if the branch already exist. Available values: skip, append, replace")
+	cmd.Flags().StringP("conflict-strategy", "", "skip", `What should happen if the branch already exist.
+Available values:
+  skip: Skip making any changes to the existing branch and do not create a new pull request.
+  replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.`)
 	cmd.Flags().StringP("author-name", "", "", "Name of the committer. If not set, the global git config setting will be used.")
 	cmd.Flags().StringP("author-email", "", "", "Email of the committer. If not set, the global git config setting will be used.")
 	configureGit(cmd)

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -48,7 +48,11 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringP("conflict-strategy", "", "skip", `What should happen if the branch already exist.
 Available values:
   skip: Skip making any changes to the existing branch and do not create a new pull request.
-  replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.`)
+  replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.
+`)
+	_ = cmd.RegisterFlagCompletionFunc("conflict-strategy", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"skip", "replace"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	cmd.Flags().StringP("author-name", "", "", "Name of the committer. If not set, the global git config setting will be used.")
 	cmd.Flags().StringP("author-email", "", "", "Email of the committer. If not set, the global git config setting will be used.")
 	configureGit(cmd)

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -45,6 +45,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
 	cmd.Flags().BoolP("interactive", "i", false, "Take manual decision before committing any change. Requires git to be installed.")
 	cmd.Flags().BoolP("dry-run", "d", false, "Run without pushing changes or creating pull requests.")
+	cmd.Flags().StringP("conflict-strategy", "", "skip", "What should happen if the branch already exist. Available values: skip, append, replace")
 	cmd.Flags().StringP("author-name", "", "", "Name of the committer. If not set, the global git config setting will be used.")
 	cmd.Flags().StringP("author-email", "", "", "Email of the committer. If not set, the global git config setting will be used.")
 	configureGit(cmd)
@@ -74,6 +75,7 @@ func run(cmd *cobra.Command, args []string) error {
 	dryRun, _ := flag.GetBool("dry-run")
 	forkMode, _ := flag.GetBool("fork")
 	forkOwner, _ := flag.GetString("fork-owner")
+	conflictStrategyStr, _ := flag.GetString("conflict-strategy")
 	authorName, _ := flag.GetString("author-name")
 	authorEmail, _ := flag.GetString("author-email")
 	strOutput, _ := flag.GetString("output")
@@ -139,6 +141,11 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	conflictStrategy, err := multigitter.ParseConflictStrategy(conflictStrategyStr)
+	if err != nil {
+		return err
+	}
+
 	// Set up signal listening to cancel the context and let started runs finish gracefully
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
@@ -174,6 +181,7 @@ func run(cmd *cobra.Command, args []string) error {
 		CommitAuthor:     commitAuthor,
 		BaseBranch:       baseBranchName,
 		Assignees:        assignees,
+		ConflictStrategy: conflictStrategy,
 
 		Concurrent: concurrent,
 

--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -129,8 +129,14 @@ func (g *Git) BranchExist(remoteName, branchName string) (bool, error) {
 }
 
 // Push the committed changes to the remote
-func (g *Git) Push(remoteName string) error {
-	cmd := exec.Command("git", "push", "--no-verify", remoteName, "HEAD")
+func (g *Git) Push(remoteName string, force bool) error {
+	args := []string{"push", "--no-verify", remoteName}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, "HEAD")
+
+	cmd := exec.Command("git", args...)
 	_, err := g.run(cmd)
 	return err
 }

--- a/internal/git/gogit/git.go
+++ b/internal/git/gogit/git.go
@@ -186,9 +186,10 @@ func (g *Git) BranchExist(remoteName, branchName string) (bool, error) {
 }
 
 // Push the committed changes to the remote
-func (g *Git) Push(remoteName string) error {
+func (g *Git) Push(remoteName string, force bool) error {
 	return g.repo.Push(&git.PushOptions{
 		RemoteName: remoteName,
+		Force:      force,
 	})
 }
 

--- a/internal/multigitter/shared.go
+++ b/internal/multigitter/shared.go
@@ -29,7 +29,7 @@ type Git interface {
 	Changes() (bool, error)
 	Commit(commitAuthor *git.CommitAuthor, commitMessage string) error
 	BranchExist(remoteName, branchName string) (bool, error)
-	Push(remoteName string) error
+	Push(remoteName string, force bool) error
 	AddRemote(name, url string) error
 }
 
@@ -46,4 +46,26 @@ func getStackTrace(err error) string {
 		return trace
 	}
 	return ""
+}
+
+// ConflictStrategy define how a conflict of an already existing branch should be handled
+type ConflictStrategy int
+
+const (
+	// ConflictStrategySkip will skip the run for if the branch does already exist
+	ConflictStrategySkip ConflictStrategy = iota + 1
+	// ConflictStrategyReplace will ignore any existing branch and replace it with new changes
+	ConflictStrategyReplace
+)
+
+// ParseConflictStrategy parses a conflict strategy from a string
+func ParseConflictStrategy(str string) (ConflictStrategy, error) {
+	switch str {
+	default:
+		return ConflictStrategy(0), fmt.Errorf("could not parse \"%s\" as conflict strategy", str)
+	case "skip":
+		return ConflictStrategySkip, nil
+	case "replace":
+		return ConflictStrategyReplace, nil
+	}
 }

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -367,19 +367,15 @@ func (g *Github) loggedInUser(ctx context.Context) (string, error) {
 // This is normally the owner of the original repository, but if a fork has been made
 // it will be a different owner
 func (g *Github) headOwner(ctx context.Context, repoOwner string) (string, error) {
-	headOwner := repoOwner
-	if g.Fork {
-		if g.ForkOwner != "" {
-			headOwner = g.ForkOwner
-		} else {
-			var err error
-			headOwner, err = g.loggedInUser(ctx)
-			if err != nil {
-				return "", err
-			}
-		}
+	if !g.Fork {
+		return repoOwner, nil
 	}
-	return headOwner, nil
+
+	if g.ForkOwner != "" {
+		return g.ForkOwner, nil
+	}
+
+	return g.loggedInUser(ctx)
 }
 
 // GetOpenPullRequest gets a pull request for one specific repository

--- a/tests/vcmock/vcmock.go
+++ b/tests/vcmock/vcmock.go
@@ -65,6 +65,25 @@ func (vc *VersionController) GetPullRequests(ctx context.Context, branchName str
 	return ret, nil
 }
 
+// GetOpenPullRequest gets mock open pull request
+func (vc *VersionController) GetOpenPullRequest(ctx context.Context, repo scm.Repository, branchName string) (scm.PullRequest, error) {
+	vc.prLock.RLock()
+	defer vc.prLock.RUnlock()
+
+	r := repo.(Repository)
+
+	for _, pr := range vc.PullRequests {
+		if r.OwnerName == pr.OwnerName && r.RepoName == pr.RepoName && pr.NewPullRequest.Head == branchName && openPullRequest(pr) {
+			return pr, nil
+		}
+	}
+	return nil, nil
+}
+
+func openPullRequest(pr PullRequest) bool {
+	return pr.PRStatus == scm.PullRequestStatusSuccess || pr.PRStatus == scm.PullRequestStatusPending
+}
+
 // MergePullRequest sets the status of a mock pull requests to merged
 func (vc *VersionController) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
 	vc.prLock.Lock()


### PR DESCRIPTION
This branchs adds `--conflict-strategy` and implements `skip` (previous default behaviour) and `replace`, where the changes to existing branches are replaced by a force push. The `append` strategy is intended to be implemented, but requires more additions and will be done separately. 

| Type | Description |
|-|-|
| Skip| The current behavior and the behavior that should most likely always be the default. Simply skip making any changes to the branch |
| ~Append~ | ~The changes are made on top of any already existing commits in the branch.~ |
| Replace | If a branch already exist and a change was made, replace it the new changes, and force push the changes. |

Closes #205
