### PR TITLE
fix(bitbucket): ensure username is set

### DIFF
--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -253,6 +253,10 @@ func createBitbucketServerClient(flag *flag.FlagSet, verifyFlags bool) (multigit
 		return nil, errors.New("no base-url set for bitbucket server")
 	}
 
+	if username == "" {
+		return nil, errors.New("no username set")
+	}
+
 	token, err := getToken(flag)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Ensure username is set so that bitbucket_server scm does not fail.

# What does this change
Validates that the `username` field is set for the `bitbucket_server` SCM type.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
