### PR TITLE
feat(gitlab): respect project level squash setting

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -227,7 +227,7 @@ func (g *Gitlab) CreatePullRequest(ctx context.Context, repo scm.Repository, prR
 		TargetProjectID:    &r.pid,
 		ReviewerIDs:        reviewersIDs,
 		RemoveSourceBranch: &removeSourceBranch,
-		Squash:				&squash,
+		Squash:             &squash,
 		AssigneeIDs:        assigneesIDs,
 	})
 	if err != nil {

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -219,7 +219,7 @@ func (g *Gitlab) CreatePullRequest(ctx context.Context, repo scm.Repository, prR
 
 	// Fetch project level settings to determine squash option.
 	// See Gitlab Docs: https://docs.gitlab.com/ee/user/project/merge_requests/squash_and_merge.html#configure-squash-options-for-a-project
-	project,_, err := g.glClient.Projects.GetProject(r.pid, nil, gitlab.WithContext(ctx))
+	project, _, err := g.glClient.Projects.GetProject(r.pid, nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -218,6 +218,7 @@ func (g *Gitlab) CreatePullRequest(ctx context.Context, repo scm.Repository, prR
 	}
 
 	removeSourceBranch := true
+	squash := true
 	mr, _, err := g.glClient.MergeRequests.CreateMergeRequest(prR.pid, &gitlab.CreateMergeRequestOptions{
 		Title:              &newPR.Title,
 		Description:        &newPR.Body,
@@ -226,6 +227,7 @@ func (g *Gitlab) CreatePullRequest(ctx context.Context, repo scm.Repository, prR
 		TargetProjectID:    &r.pid,
 		ReviewerIDs:        reviewersIDs,
 		RemoveSourceBranch: &removeSourceBranch,
+		Squash:				&squash,
 		AssigneeIDs:        assigneesIDs,
 	})
 	if err != nil {

--- a/internal/scm/gitlab/repository.go
+++ b/internal/scm/gitlab/repository.go
@@ -31,9 +31,7 @@ func (g *Gitlab) convertProject(project *gitlab.Project) (repository, error) {
 }
 
 func shouldSquash(project *gitlab.Project) bool {
-	setting := project.SquashOption
-
-	switch setting {
+	switch project.SquashOption {
 	case gitlab.SquashOptionAlways, gitlab.SquashOptionDefaultOn:
 		return true
 	case gitlab.SquashOptionNever, gitlab.SquashOptionDefaultOff:

--- a/internal/scm/gitlab/repository.go
+++ b/internal/scm/gitlab/repository.go
@@ -26,7 +26,21 @@ func (g *Gitlab) convertProject(project *gitlab.Project) (repository, error) {
 		name:          project.Path,
 		ownerName:     project.Namespace.Path,
 		defaultBranch: project.DefaultBranch,
+		shouldSquash:  shouldSquash(project),
 	}, nil
+}
+
+func shouldSquash(project *gitlab.Project) bool {
+	setting := project.SquashOption
+
+	switch setting {
+	case gitlab.SquashOptionAlways, gitlab.SquashOptionDefaultOn:
+		return true
+	case gitlab.SquashOptionNever, gitlab.SquashOptionDefaultOff:
+		return false
+	default:
+		return false
+	}
 }
 
 type repository struct {
@@ -35,6 +49,7 @@ type repository struct {
 	name          string
 	ownerName     string
 	defaultBranch string
+	shouldSquash  bool
 }
 
 func (r repository) CloneURL() string {


### PR DESCRIPTION
# What does this change
This PR sets the `Squash on merge` based on the project setting.

# What issue does it fix
No issue has been created. I can do that if desired.

In my case I want to make some altercations after creating the Multi-Gitter MRs, but I almost always squash Merge Requests for a clean history on the main branch.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
