### PR TITLE
fix(gitlab): close MR instead of deleting it

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -390,7 +390,10 @@ func (g *Gitlab) MergePullRequest(ctx context.Context, pullReq scm.PullRequest) 
 func (g *Gitlab) ClosePullRequest(ctx context.Context, pullReq scm.PullRequest) error {
 	pr := pullReq.(pullRequest)
 
-	_, err := g.glClient.MergeRequests.DeleteMergeRequest(pr.targetPID, pr.iid, gitlab.WithContext(ctx))
+	stateEvent := "close"
+	_, _, err := g.glClient.MergeRequests.UpdateMergeRequest(pr.targetPID, pr.iid, &gitlab.UpdateMergeRequestOptions{
+		StateEvent: &stateEvent,
+	}, gitlab.WithContext(ctx))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this change
Changes the wrong behavior of deleting the Merge Request to closing the Merge Request.

![image](https://user-images.githubusercontent.com/17970041/152565037-7f1ff76b-4e04-4736-b63f-bafc2c435770.png)

# What issue does it fix
Closes #229 

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
