### PR TITLE
Add Clone script

### DIFF
--- a/examples/general/clone.sh
+++ b/examples/general/clone.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Title: Clone all repositories locally while maintaining their group folder structure
+
+# This script should be used with the print command.
+mkdir -p ~/multi-gitter/$REPOSITORY
+cp -r . ~/multi-gitter/$REPOSITORY

--- a/internal/scm/gitlab/repository.go
+++ b/internal/scm/gitlab/repository.go
@@ -24,7 +24,7 @@ func (g *Gitlab) convertProject(project *gitlab.Project) (repository, error) {
 		url:           cloneURL,
 		pid:           project.ID,
 		name:          project.Path,
-		ownerName:     project.Namespace.Path,
+		ownerName:     project.Namespace.FullPath,
 		defaultBranch: project.DefaultBranch,
 		shouldSquash:  shouldSquash(project),
 	}, nil


### PR DESCRIPTION
# What does this change
This commit adds clone.sh, which clones the repositories down and copies them to a local folder while maintaining their org/user/group structure via folders.

It also fixes a possible bug as part of the gitlab api - the project.Namespace.Path value only contains the lowest subgroup, where the FullPath gets the entire group structure. 

# What issue does it fix
Discussion #234 

# Notes for the reviewer
Can you consider the implications of changing project.Namespace.Path to .FullPath? Will this cause any known issues?

# Checklist
- [ ] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
