### PR TITLE
feat(gitlab): skip archived repos

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -146,12 +146,14 @@ func (g *Gitlab) getProjects(ctx context.Context) ([]*gitlab.Project, error) {
 func (g *Gitlab) getGroupProjects(ctx context.Context, groupName string) ([]*gitlab.Project, error) {
 	var allProjects []*gitlab.Project
 	withMergeRequestsEnabled := true
+	archived := false
 	for i := 1; ; i++ {
 		projects, _, err := g.glClient.Groups.ListGroupProjects(groupName, &gitlab.ListGroupProjectsOptions{
 			ListOptions: gitlab.ListOptions{
 				PerPage: 100,
 				Page:    i,
 			},
+			Archived:                 &archived,
 			IncludeSubgroups:         &g.Config.IncludeSubgroups,
 			WithMergeRequestsEnabled: &withMergeRequestsEnabled,
 		}, gitlab.WithContext(ctx))
@@ -182,12 +184,14 @@ func (g *Gitlab) getProject(ctx context.Context, projRef ProjectReference) (*git
 
 func (g *Gitlab) getUserProjects(ctx context.Context, username string) ([]*gitlab.Project, error) {
 	var allProjects []*gitlab.Project
+	archived := false
 	for i := 1; ; i++ {
 		projects, _, err := g.glClient.Projects.ListUserProjects(username, &gitlab.ListProjectsOptions{
 			ListOptions: gitlab.ListOptions{
 				PerPage: 100,
 				Page:    i,
 			},
+			Archived: &archived,
 		}, gitlab.WithContext(ctx))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# What does this change
Skip `archived` projects when retrieving repositories for group/user projects on GitLab.

# What issue does it fix
If a repository is archived on GitLab it is read-only. Therefor no changes can be made to the repository. 
Currently `multi-gitter` will still clone the repository and (try to) make changes for it. 

With the GitHub SCM archived repositories were already skipped. This PR also adds this behavior for GitLab.

# Notes for the reviewer
N/A

# Checklist
- [X] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
