### PR TITLE
fix(github): allow only pull permission for print command

### DIFF
--- a/cmd/cmd-close.go
+++ b/cmd/cmd-close.go
@@ -32,7 +32,7 @@ func close(cmd *cobra.Command, args []string) error {
 
 	branchName, _ := flag.GetString("branch")
 
-	vc, err := getVersionController(flag, true)
+	vc, err := getVersionController(flag, true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd-merge.go
+++ b/cmd/cmd-merge.go
@@ -33,7 +33,7 @@ func merge(cmd *cobra.Command, args []string) error {
 
 	branchName, _ := flag.GetString("branch")
 
-	vc, err := getVersionController(flag, true)
+	vc, err := getVersionController(flag, true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd-print.go
+++ b/cmd/cmd-print.go
@@ -48,6 +48,8 @@ func print(cmd *cobra.Command, args []string) error {
 	strOutput, _ := flag.GetString("output")
 	strErrOutput, _ := flag.GetString("error-output")
 
+	_ = flag.Set("readOnly", "true")
+
 	if concurrent < 1 {
 		return errors.New("concurrent runs can't be less than one")
 	}

--- a/cmd/cmd-print.go
+++ b/cmd/cmd-print.go
@@ -48,8 +48,6 @@ func print(cmd *cobra.Command, args []string) error {
 	strOutput, _ := flag.GetString("output")
 	strErrOutput, _ := flag.GetString("error-output")
 
-	_ = flag.Set("readOnly", "true")
-
 	if concurrent < 1 {
 		return errors.New("concurrent runs can't be less than one")
 	}
@@ -64,7 +62,7 @@ func print(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	vc, err := getVersionController(flag, true)
+	vc, err := getVersionController(flag, true, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -135,7 +135,7 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	vc, err := getVersionController(flag, true)
+	vc, err := getVersionController(flag, true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd-status.go
+++ b/cmd/cmd-status.go
@@ -35,7 +35,7 @@ func status(cmd *cobra.Command, args []string) error {
 	branchName, _ := flag.GetString("branch")
 	strOutput, _ := flag.GetString("output")
 
-	vc, err := getVersionController(flag, true)
+	vc, err := getVersionController(flag, true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -31,6 +31,10 @@ func configurePlatform(cmd *cobra.Command) {
 	flags.BoolP("include-subgroups", "", false, "Include GitLab subgroups when using the --group flag.")
 	flags.BoolP("ssh-auth", "", false, `Use SSH cloning URL instead of HTTPS + token. This requires that a setup with ssh keys that have access to all repos and that the server is already in known_hosts.`)
 
+	// This is only used by PrintCmd to mark readOnly mode for version control platform
+	flags.Bool("readOnly", false, "If set, This is running in readonly will be read-only.")
+	_ = flags.MarkHidden("readOnly")
+
 	flags.StringP("platform", "p", "github", "The platform that is used. Available values: github, gitlab, gitea, bitbucket_server.")
 	_ = cmd.RegisterFlagCompletionFunc("platform", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"github", "gitlab", "gitea", "bitbucket_server"}, cobra.ShellCompDirectiveDefault
@@ -122,6 +126,7 @@ func createGithubClient(flag *flag.FlagSet, verifyFlags bool) (multigitter.Versi
 	forkMode, _ := flag.GetBool("fork")
 	forkOwner, _ := flag.GetString("fork-owner")
 	sshAuth, _ := flag.GetBool("ssh-auth")
+	readOnly, _ := flag.GetBool("readOnly")
 
 	if verifyFlags && len(orgs) == 0 && len(users) == 0 && len(repos) == 0 {
 		return nil, errors.New("no organization, user or repo set")
@@ -149,7 +154,7 @@ func createGithubClient(flag *flag.FlagSet, verifyFlags bool) (multigitter.Versi
 		Organizations: orgs,
 		Users:         users,
 		Repositories:  repoRefs,
-	}, mergeTypes, forkMode, forkOwner, sshAuth)
+	}, mergeTypes, forkMode, forkOwner, sshAuth, readOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -117,7 +117,7 @@ func Test_GetRepositories(t *testing.T) {
 	{
 		gh, err := github.New("", "", transport.Wrapper, github.RepositoryListing{
 			Organizations: []string{"test-org"},
-		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false)
+		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false, false)
 		require.NoError(t, err)
 
 		repos, err := gh.GetRepositories(context.Background())
@@ -137,7 +137,7 @@ func Test_GetRepositories(t *testing.T) {
 					Name:      "test1",
 				},
 			},
-		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false)
+		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false, false)
 		require.NoError(t, err)
 
 		repos, err := gh.GetRepositories(context.Background())
@@ -152,7 +152,7 @@ func Test_GetRepositories(t *testing.T) {
 	{
 		gh, err := github.New("", "", transport.Wrapper, github.RepositoryListing{
 			Users: []string{"test-user"},
-		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false)
+		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false, false)
 		require.NoError(t, err)
 
 		repos, err := gh.GetRepositories(context.Background())
@@ -174,7 +174,7 @@ func Test_GetRepositories(t *testing.T) {
 					Name:      "test1",
 				},
 			},
-		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false)
+		}, []scm.MergeType{scm.MergeTypeMerge}, false, "", false, false)
 		require.NoError(t, err)
 
 		repos, err := gh.GetRepositories(context.Background())


### PR DESCRIPTION
Without configuring platform run options. Not all repos are downloaded due to conditions.

# What does this change

Instead of:
DEBU[0000] Skipping repository since the token does not have push permissions and the run will not fork  repo=jenkinsci/opslevel-plugin
INFO[0000] Running on 0 repositories

You get:
INFO[0000] Running on 1 repositories
INFO[0000] Cloning and running script                    repo=jenkinsci/opslevel-plugin

Since jenkinsci/opslevel-plugin is a fork I have no push permissions and g.Fork always being false because `configureRunPlatform` is never run.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
