### PR TITLE
fix: return open PRs only

### DIFF
--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -326,12 +326,13 @@ func (g *Github) GetPullRequests(ctx context.Context, branchName string) ([]scm.
 
 	// The fragment is all the data needed from every repository
 	const fragment = `fragment repoProperties on Repository {
-		pullRequests(headRefName: $branchName, states: OPEN, last: 1) {
+		pullRequests(headRefName: $branchName, last: 1) {
 			nodes {
 				number
 				headRefName
 				closed
 				url
+				merged
 				baseRepository {
 					name
 					owner {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -326,7 +326,7 @@ func (g *Github) GetPullRequests(ctx context.Context, branchName string) ([]scm.
 
 	// The fragment is all the data needed from every repository
 	const fragment = `fragment repoProperties on Repository {
-		pullRequests(headRefName: $branchName, last: 1) {
+		pullRequests(headRefName: $branchName, states: OPEN, last: 1) {
 			nodes {
 				number
 				headRefName

--- a/internal/scm/github/graphql.go
+++ b/internal/scm/github/graphql.go
@@ -116,6 +116,7 @@ type graphqlPR struct {
 	HeadRefName    string `json:"headRefName"`
 	Closed         bool   `json:"closed"`
 	URL            string `json:"url"`
+	Merged         bool   `json:"merged"`
 	BaseRepository struct {
 		Name  string `json:"name"`
 		Owner struct {

--- a/internal/scm/github/pullrequest.go
+++ b/internal/scm/github/pullrequest.go
@@ -24,7 +24,9 @@ func convertGraphQLPullRequest(pr graphqlPR) pullRequest {
 	combinedStatus := pr.Commits.Nodes[0].Commit.StatusCheckRollup.State
 	status := scm.PullRequestStatusUnknown
 
-	if combinedStatus == nil {
+	if pr.Merged {
+		status = scm.PullRequestStatusMerged
+	} else if combinedStatus == nil {
 		status = scm.PullRequestStatusSuccess
 	} else {
 		switch *combinedStatus {


### PR DESCRIPTION
# What does this change

Once a change was partially merged, no further merge operations were possible as mutli-gitter tried to merge already merged PRs and GitHub returned.

`PUT https://api.github.com/repos/XYZ/pulls/40/merge: 405 Pull Request is not mergeable []`

Instead of returning all PRs for a branch, return only open PRs as there is currently no way to interact with already closed PRs.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
