### PR TITLE
fix: deleted files are now detected with `git-type: go`

### DIFF
--- a/internal/git/gogit/git.go
+++ b/internal/git/gogit/git.go
@@ -95,6 +95,22 @@ func (g *Git) Commit(commitAuthor *internalgit.CommitAuthor, commitMessage strin
 		return err
 	}
 
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+
+	// This is a workaround for a bug in go-git where "add all" does not add deleted files
+	// If https://github.com/go-git/go-git/issues/223 is fixed, this can be removed
+	for file, s := range status {
+		if s.Worktree == git.Deleted {
+			_, err = w.Add(file)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	// Get the current hash to be able to diff it with the committed changes later
 	oldHead, err := g.repo.Head()
 	if err != nil {

--- a/tests/scripts/remover/main.go
+++ b/tests/scripts/remover/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Remove("test_file")
+}


### PR DESCRIPTION
# What does this change
Implements workaround where go-git would not add deleted files to the commit. It can hopefully be removed in the future. 

# What issue does it fix
Closes #266 

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
