### PR TITLE
fix: Dont try to merge already merged PRs

### DIFF
--- a/internal/multigitter/merge.go
+++ b/internal/multigitter/merge.go
@@ -23,7 +23,7 @@ func (s Merger) Merge(ctx context.Context) error {
 
 	successPrs := make([]scm.PullRequest, 0, len(prs))
 	for _, pr := range prs {
-		if pr.Status() == scm.PullRequestStatusSuccess {
+		if pr.Status() == scm.PullRequestStatusSuccess && pr.Status() != scm.PullRequestStatusMerged {
 			successPrs = append(successPrs, pr)
 		}
 	}


### PR DESCRIPTION
# What does this change
Merging fails if a PR is already merged, halting the whole merge process. I belive that one should not try to merge already merged PRs.
