### PR TITLE
fix: ignore missing reference on pr close

### DIFF
--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -536,7 +536,12 @@ func (g *Github) ClosePullRequest(ctx context.Context, pullReq scm.PullRequest) 
 	}
 
 	_, err = g.ghClient.Git.DeleteRef(ctx, pr.prOwnerName, pr.prRepoName, fmt.Sprintf("heads/%s", pr.branchName))
-	return err
+	// Ignore errors about the reference not existing in case the PR had already been closed and the branch deleted
+	if err != nil && !strings.Contains(err.Error(), "Reference does not exist") {
+		return err
+	}
+
+	return nil
 }
 
 // ForkRepository forks a repository. If newOwner is empty, fork on the logged in user

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -531,13 +531,13 @@ func (g *Github) ClosePullRequest(ctx context.Context, pullReq scm.PullRequest) 
 	_, _, err := g.ghClient.PullRequests.Edit(ctx, pr.ownerName, pr.repoName, pr.number, &github.PullRequest{
 		State: &[]string{"closed"}[0],
 	})
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "Not Found") {
 		return err
 	}
 
 	_, err = g.ghClient.Git.DeleteRef(ctx, pr.prOwnerName, pr.prRepoName, fmt.Sprintf("heads/%s", pr.branchName))
 	// Ignore errors about the reference not existing in case the PR had already been closed and the branch deleted
-	if err != nil && !strings.Contains(err.Error(), "Reference does not exist") {
+	if err != nil && !strings.Contains(err.Error(), "Reference does not exist") && !strings.Contains(err.Error(), "Not Found") {
 		return err
 	}
 


### PR DESCRIPTION
# What does this change
Ignore "Reference does not exist" error when closing a PR. 

# What issue does it fix
While closing a bunch of PRs I noticed that the program errored with:

```
INFO[0003] Closing 91 pull requests                     
INFO[0003] Closing                                       pr="<redacted> #163"
Error: DELETE https://<redacted>/git/refs/heads/<redacted>: 422 Reference does not exist []
Usage:
  multi-gitter close [flags]

Flags:
  -g, --base-url string     Base <...>
```

# Notes for the reviewer

Maybe we should not try to close already closed PRs?

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
