### PR TITLE
fix: typos in docs and code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing Guide
 ----
 
-We welcome dontributions in multiple forms. This file describes some of the ways how you can help out in various ways.
+We welcome contributions in multiple forms. This file describes some of the ways how you can help out in various ways.
 
 ## Bug fixes or new feature
 

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -19,7 +19,7 @@ func configureLogging(cmd *cobra.Command, logFile string) {
 		return []string{"trace", "debug", "info", "error"}, cobra.ShellCompDirectiveDefault
 	})
 
-	flags.StringP("log-format", "", "text", `The formating of the logs. Available values: text, json, json-pretty.`)
+	flags.StringP("log-format", "", "text", `The formatting of the logs. Available values: text, json, json-pretty.`)
 	_ = cmd.RegisterFlagCompletionFunc("log-format", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"text", "json", "json-pretty"}, cobra.ShellCompDirectiveDefault
 	})

--- a/internal/log/censor-formatter.go
+++ b/internal/log/censor-formatter.go
@@ -8,12 +8,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// NewCensorFormatter creates a new formater that censors sensitive logs.
+// NewCensorFormatter creates a new formatter that censors sensitive logs.
 // It contains some default censoring rules, but additional items may be used
-func NewCensorFormatter(underlyingFormater log.Formatter, additionalCensoring ...CensorItem) *CensorFormatter {
+func NewCensorFormatter(underlyingFormatter log.Formatter, additionalCensoring ...CensorItem) *CensorFormatter {
 	return &CensorFormatter{
 		CensorItems:         append(defaultCensorItems, additionalCensoring...),
-		UnderlyingFormatter: underlyingFormater,
+		UnderlyingFormatter: underlyingFormatter,
 	}
 }
 

--- a/internal/log/censor-formatter_test.go
+++ b/internal/log/censor-formatter_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type dummyFormater struct {
+type dummyFormatter struct {
 	entry logrus.Entry
 }
 
-func (f *dummyFormater) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *dummyFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	f.entry = *entry
 	return []byte{}, nil
 }
@@ -119,16 +119,16 @@ Some Data`),
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dummyFormater := &dummyFormater{}
+			dummyFormatter := &dummyFormatter{}
 			formatter := CensorFormatter{
 				CensorItems:         test.items,
-				UnderlyingFormatter: dummyFormater,
+				UnderlyingFormatter: dummyFormatter,
 			}
 			_, err := formatter.Format(&test.entry)
 			assert.NoError(t, err)
 
-			assert.Equal(t, test.expectedData, dummyFormater.entry.Data)
-			assert.Equal(t, test.expectedMessage, dummyFormater.entry.Message)
+			assert.Equal(t, test.expectedData, dummyFormatter.entry.Data)
+			assert.Equal(t, test.expectedMessage, dummyFormatter.entry.Message)
 		})
 	}
 }

--- a/internal/multigitter/repocounter/counter.go
+++ b/internal/multigitter/repocounter/counter.go
@@ -49,7 +49,7 @@ func (r *Counter) AddSuccessPullRequest(repo scm.PullRequest) {
 	r.successPullRequests = append(r.successPullRequests, repo)
 }
 
-// Info returns a formated string about all repositories
+// Info returns a formatted string about all repositories
 func (r *Counter) Info() string {
 	defer r.lock.RUnlock()
 	r.lock.RLock()

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -655,7 +655,7 @@ func (g *Github) GetAutocompleteRepositories(ctx context.Context, str string) ([
 	var q string
 
 	// If the user has already provided a org/user, it's much more effective to search based on that
-	// comparared to a complete freetext search
+	// comparared to a complete free text search
 	splitted := strings.SplitN(str, "/", 2)
 	switch {
 	case len(splitted) == 2:

--- a/tests/story_test.go
+++ b/tests/story_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStory tests the common usecase: run, status, merge, status
+// TestStory tests the common use case: run, status, merge, status
 func TestStory(t *testing.T) {
 	vcMock := &vcmock.VersionController{}
 	defer vcMock.Clean()


### PR DESCRIPTION
# What does this change
Fixes some typos in documentation, code, and comments.
