### PR TITLE
Fix installation on Windows

### DIFF
--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -1,0 +1,29 @@
+---
+name: Test install.sh
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-install.yaml
+      - install.sh
+
+jobs:
+  test-install-sh:
+    name: Test install.sh
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install multi-gitter
+        env:
+          BINDIR: ${{ github.workspace }}/bin
+        run: |
+          curl -s https://raw.githubusercontent.com/fabasoad/multi-gitter/${{ github.ref_name }}/install.sh | sh -s -- -d
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+        shell: sh
+      - name: Print version
+        run: multi-gitter version
+        shell: sh

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Dump GitHub context
-        run: echo '${{ toJSON(github) }}'
+        run: echo "${{ toJSON(github) }}"
+        shell: sh
       - name: Install multi-gitter
         env:
           BINDIR: ${{ github.workspace }}/bin

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -17,11 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        run: echo '${{ toJSON(github) }}'
       - name: Install multi-gitter
         env:
           BINDIR: ${{ github.workspace }}/bin
         run: |
-          sudo ./install.sh -d
+          curl -s https://raw.githubusercontent.com/lindell/multi-gitter/master/install.sh | sh -s -- -d
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
         shell: sh
       - name: Print version

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -21,7 +21,7 @@ jobs:
         env:
           BINDIR: ${{ github.workspace }}/bin
         run: |
-          curl -s https://raw.githubusercontent.com/lindell/multi-gitter/${{ github.ref_name }}/install.sh | sh -s -- -d
+          ./install.sh -d
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
         shell: sh
       - name: Print version

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Dump GitHub context
-        run: echo "${{ toJSON(github) }}"
+        run: echo "https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref }}/install.sh"
         shell: sh
       - name: Install multi-gitter
         env:

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -21,7 +21,7 @@ jobs:
         env:
           BINDIR: ${{ github.workspace }}/bin
         run: |
-          ./install.sh -d
+          sudo ./install.sh -d
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
         shell: sh
       - name: Print version

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Dump GitHub context
-        run: echo "https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref }}/install.sh"
-        shell: sh
       - name: Install multi-gitter
         env:
           BINDIR: ${{ github.workspace }}/bin

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -24,7 +24,7 @@ jobs:
         env:
           BINDIR: ${{ github.workspace }}/bin
         run: |
-          curl -s https://raw.githubusercontent.com/lindell/multi-gitter/master/install.sh | sh -s -- -d
+          curl -s https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref }}/install.sh | sh -s -- -d
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
         shell: sh
       - name: Print version

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -21,7 +21,7 @@ jobs:
         env:
           BINDIR: ${{ github.workspace }}/bin
         run: |
-          curl -s https://raw.githubusercontent.com/fabasoad/multi-gitter/${{ github.ref_name }}/install.sh | sh -s -- -d
+          curl -s https://raw.githubusercontent.com/lindell/multi-gitter/${{ github.ref_name }}/install.sh | sh -s -- -d
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
         shell: sh
       - name: Print version

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download go binaries for lindell/multi-gitter
 
 Usage: $this [-b] bindir [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to /usr/local/bin
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/lindell/multi-gitter/releases
@@ -51,15 +51,10 @@ execute() {
   (cd "${tmpdir}" && untar "${TARBALL}")
   test ! -d "${BINDIR}" && install -d "${BINDIR}"
   for binexe in $BINARIES; do
-    if [ "$OS" = "windows" ]; then
+    if [ "$OS" = "Windows" ]; then
       binexe="${binexe}.exe"
     fi
-    if test -w "${BINDIR}/${binexe}"; then
-      install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
-    else
-      log_info "not allowed to install binary without higher privilege"
-      sudo install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
-    fi
+    install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
     log_info "installed ${BINDIR}/${binexe}"
   done
   rm -rf "${tmpdir}"
@@ -98,13 +93,6 @@ tag_to_version() {
   # if version starts with 'v', remove it
   TAG="$REALTAG"
   VERSION=${TAG#v}
-}
-adjust_format() {
-  # change format based on OS
-  case ${OS} in
-    windows) FORMAT=.exe ;;
-  esac
-  true
 }
 adjust_os() {
   # adjust archive name based on OS
@@ -387,8 +375,6 @@ parse_args "$@"
 get_binaries
 
 tag_to_version
-
-adjust_format
 
 adjust_os
 

--- a/install.sh
+++ b/install.sh
@@ -52,13 +52,14 @@ execute() {
   test ! -d "${BINDIR}" && install -d "${BINDIR}"
   for binexe in $BINARIES; do
     if [ "$OS" = "Windows" ]; then
-      binexe="${binexe}.exe"
-    fi
-    if [ "$OS" = "Windows" ] || [ test -w "${BINDIR}/${binexe}" ]; then
-      install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+      install "${srcdir}/${binexe}.exe" "${BINDIR}/${binexe}.exe"
     else
-      log_info "not allowed to install binary without higher privilege"
-      sudo install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+      if test -w "${BINDIR}/${binexe}"; then
+        install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+      else
+        log_info "not allowed to install binary without higher privilege"
+        sudo install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+      fi
     fi
     log_info "installed ${BINDIR}/${binexe}"
   done

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,12 @@ execute() {
     if [ "$OS" = "Windows" ]; then
       binexe="${binexe}.exe"
     fi
-    install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+    if [ "$OS" = "Windows" ] || [ test -w "${BINDIR}/${binexe}" ]; then
+      install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+    else
+      log_info "not allowed to install binary without higher privilege"
+      sudo install "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+    fi
     log_info "installed ${BINDIR}/${binexe}"
   done
   rm -rf "${tmpdir}"


### PR DESCRIPTION
# What does this change

There are multiple fixes have been done to fix Windows installation:
1. `$OS` was comparing to _"windows"_ with first letter in lowercase, but it should be in uppercase
2. Removed `sudo install ...` line as it was a problem line for Windows.
3. Removed `adjust_format` function and its calling.

# What issue does it fix

Closes #306

# Notes for the reviewer

For the changes above:

**(2)** I ran it on macOS, Linux & Windows and everything passed successfully. Though, I feel that it might have impact on some users' environments, so it's up to the repo owner should `sudo` be back and another approach found or not.
**(3)** This one just doesn't make sense as all artifacts have `.tar.gz` format.

Also, I have added `.github/workflows/test-install.sh` pipeline to be sure that it is not broken in a future.

For future improvements:

1. Should line 54 (`if [ "$OS" = "Windows" ]; then`) be rewritten to be case agnostic maybe? 🤔 
2. Would be great to add all supported OS to `.github/workflows/test-install.sh` (CentOS, Alpine, etc.).

# Checklist

- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
