### PR TITLE
fix(github): chunk get pull requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.6.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/scm/github/graphql.go
+++ b/internal/scm/github/graphql.go
@@ -21,6 +21,7 @@ func (g *Github) makeGraphQLRequest(ctx context.Context, query string, data inte
 		Query: query,
 		Data:  data,
 	})
+
 	if err != nil {
 		return errors.WithMessage(err, "could not marshal graphql request")
 	}

--- a/internal/scm/github/util.go
+++ b/internal/scm/github/util.go
@@ -35,3 +35,12 @@ func stripSuffixIfExist(str string, suffix string) string {
 	}
 	return str
 }
+
+func chunkSlice[T any](stack []T, chunkSize int) [][]T {
+	var chunks = make([][]T, 0, (len(stack)/chunkSize)+1)
+	for chunkSize < len(stack) {
+		stack, chunks = stack[chunkSize:], append(chunks, stack[0:chunkSize:chunkSize])
+	}
+
+	return append(chunks, stack)
+}


### PR DESCRIPTION
# What does this change
Currently it is impossible to use the merge command for github if it targets a certain amount of pull requests.
if the data sent to the graphql server is too large the request fails.
I get: 
`encountered error during GraphQL query: Something went wrong while executing your query. This may be the result of a timeout, or it could be a GitHub bug. Please include `xxx` when reporting this issue.`

# What issue does it fix
This PR chunks the GetPullRequest() method into a static chunk of 50.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
