### PR TITLE
feat: filter repositories that are forks

### DIFF
--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -69,6 +69,7 @@ type RepositoryListing struct {
 	Users         []string
 	Repositories  []RepositoryReference
 	Topics        []string
+	SkipForks     bool
 }
 
 // RepositoryReference contains information to be able to reference a repository
@@ -99,6 +100,11 @@ func (g *Gitea) GetRepositories(ctx context.Context) ([]scm.Repository, error) {
 	repos := make([]scm.Repository, 0, len(allRepos))
 	for _, repo := range allRepos {
 		log := log.WithField("repo", repo.FullName)
+
+		if g.SkipForks && repo.Fork {
+			log.Debug("Skipping repository since it's a fork")
+			continue
+		}
 
 		if len(g.Topics) != 0 {
 			topics, err := g.getRepoTopics(ctx, repo)

--- a/internal/scm/gitea/repository.go
+++ b/internal/scm/gitea/repository.go
@@ -49,7 +49,3 @@ func (r repository) DefaultBranch() string {
 func (r repository) FullName() string {
 	return fmt.Sprintf("%s/%s", r.ownerName, r.name)
 }
-
-func (r repository) Fork() bool {
-	return r.fork
-}

--- a/internal/scm/gitea/repository.go
+++ b/internal/scm/gitea/repository.go
@@ -26,7 +26,6 @@ func (g *Gitea) convertRepository(repo *gitea.Repository) (repository, error) {
 		name:          repo.Name,
 		ownerName:     repo.Owner.UserName,
 		defaultBranch: repo.DefaultBranch,
-		fork:          repo.Fork,
 	}, nil
 }
 
@@ -35,7 +34,6 @@ type repository struct {
 	name          string
 	ownerName     string
 	defaultBranch string
-	fork          bool
 }
 
 func (r repository) CloneURL() string {

--- a/internal/scm/gitea/repository.go
+++ b/internal/scm/gitea/repository.go
@@ -26,6 +26,7 @@ func (g *Gitea) convertRepository(repo *gitea.Repository) (repository, error) {
 		name:          repo.Name,
 		ownerName:     repo.Owner.UserName,
 		defaultBranch: repo.DefaultBranch,
+		fork:          repo.Fork,
 	}, nil
 }
 
@@ -34,6 +35,7 @@ type repository struct {
 	name          string
 	ownerName     string
 	defaultBranch string
+	fork          bool
 }
 
 func (r repository) CloneURL() string {
@@ -46,4 +48,8 @@ func (r repository) DefaultBranch() string {
 
 func (r repository) FullName() string {
 	return fmt.Sprintf("%s/%s", r.ownerName, r.name)
+}
+
+func (r repository) Fork() bool {
+	return r.fork
 }

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -109,6 +109,7 @@ type RepositoryListing struct {
 	Users         []string
 	Repositories  []RepositoryReference
 	Topics        []string
+	SkipForks     bool
 }
 
 // RepositoryReference contains information to be able to reference a repository
@@ -157,6 +158,9 @@ func (g *Github) GetRepositories(ctx context.Context) ([]scm.Repository, error) 
 			continue
 		case len(g.Topics) != 0 && !scm.RepoContainsTopic(r.Topics, g.Topics):
 			log.Debug("Skipping repository since it does not match repository topics")
+			continue
+		case g.SkipForks && r.GetFork():
+			log.Debug("Skipping repository since it's a fork")
 			continue
 		}
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -58,6 +58,7 @@ func Test_GetRepositories(t *testing.T) {
 						"site_admin": false
 					},
 					"html_url": "https://github.com/test-org/test1",
+					"fork": false,
 					"archived": false,
 					"disabled": false,
 					"default_branch": "master",
@@ -80,6 +81,7 @@ func Test_GetRepositories(t *testing.T) {
 					"site_admin": false
 				},
 				"html_url": "https://github.com/test-org/test1",
+				"fork": false,
 				"archived": false,
 				"disabled": false,
 				"default_branch": "master",
@@ -106,6 +108,7 @@ func Test_GetRepositories(t *testing.T) {
 						"site_admin": false
 					},
 					"html_url": "https://github.com/lindell/test2",
+					"fork": true,
 					"archived": false,
 					"disabled": false,
 					"default_branch": "main",
@@ -227,6 +230,32 @@ func Test_GetRepositories(t *testing.T) {
 			assert.Equal(t, "test-org/test1", repos[0].FullName())
 			assert.Equal(t, "main", repos[1].DefaultBranch())
 			assert.Equal(t, "lindell/test2", repos[1].FullName())
+		}
+	}
+
+	// Forks
+	{
+		gh, err := github.New(github.Config{
+			TransportMiddleware: transport.Wrapper,
+			RepoListing: github.RepositoryListing{
+				Organizations: []string{"test-org"},
+				Users:         []string{"test-user"},
+				Repositories: []github.RepositoryReference{
+					{
+						OwnerName: "test-org",
+						Name:      "test1",
+					},
+				},
+				SkipForks: true,
+			},
+			MergeTypes: []scm.MergeType{scm.MergeTypeMerge},
+		})
+		require.NoError(t, err)
+
+		repos, err := gh.GetRepositories(context.Background())
+		assert.NoError(t, err)
+		if assert.Len(t, repos, 1) {
+			assert.Equal(t, "test-org/test1", repos[0].FullName())
 		}
 	}
 }

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -52,10 +52,11 @@ type Gitlab struct {
 
 // RepositoryListing contains information about which repositories that should be fetched
 type RepositoryListing struct {
-	Groups   []string
-	Users    []string
-	Projects []ProjectReference
-	Topics   []string
+	Groups    []string
+	Users     []string
+	Projects  []ProjectReference
+	Topics    []string
+	SkipForks bool
 }
 
 // Config includes extra config parameters for the GitLab client
@@ -94,6 +95,10 @@ func (g *Gitlab) GetRepositories(ctx context.Context) ([]scm.Repository, error) 
 		log := log.WithField("repo", project.NameWithNamespace)
 		if len(g.Topics) != 0 && !scm.RepoContainsTopic(project.Topics, g.Topics) {
 			log.Debug("Skipping repository since it does not match repository topics")
+			continue
+		}
+		if g.SkipForks && project.ForkedFromProject != nil {
+			log.Debug("Skipping repository since it's a fork")
 			continue
 		}
 


### PR DESCRIPTION
# What does this change

Add support for filtering out repositories that are forks using `--skip-forks`.

# What issue does it fix

See https://github.com/lindell/multi-gitter/discussions/340.

# Notes for the reviewer

None.

# Checklist

- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
