### PR TITLE
GitHub team review

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ skip-repo:
 # Use SSH cloning URL instead of HTTPS + token. This requires that a setup with ssh keys that have access to all repos and that the server is already in known_hosts.
 ssh-auth: false
 
+# Github team names of the reviewers, in format: 'org/team'
+team-reviewers:
+  - example
+
 # The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
 token:
 
@@ -620,6 +624,7 @@ Flags:
       --skip-pr                    Skip pull request and directly push to the branch.
   -s, --skip-repo strings          Skip changes on specified repositories, the name is including the owner of repository in the format "ownerName/repoName".
       --ssh-auth                   Use SSH cloning URL instead of HTTPS + token. This requires that a setup with ssh keys that have access to all repos and that the server is already in known_hosts.
+      --team-reviewers strings     Github team names of the reviewers, in format: 'org/team'
   -T, --token string               The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
       --topic strings              The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.
   -U, --user strings               The name of a user. All repositories owned by that user will be used.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,6 @@ log-level: info
 # If this value is set, reviewers will be randomized.
 max-reviewers: 0
 
-# If this value is set, team reviewers will be randomized
-max-team-reviewers: 0
-
 # The name of a GitHub organization. All repositories in that organization will be used.
 org:
   - example
@@ -224,10 +221,6 @@ skip-repo:
 
 # Use SSH cloning URL instead of HTTPS + token. This requires that a setup with ssh keys that have access to all repos and that the server is already in known_hosts.
 ssh-auth: false
-
-# Github team names of the reviewers, in format: 'org/team'
-team-reviewers:
-  - example
 
 # The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
 token:
@@ -615,7 +608,6 @@ Flags:
       --log-format string          The formatting of the logs. Available values: text, json, json-pretty. (default "text")
   -L, --log-level string           The level of logging that should be made. Available values: trace, debug, info, error. (default "info")
   -M, --max-reviewers int          If this value is set, reviewers will be randomized.
-      --max-team-reviewers int     If this value is set, team reviewers will be randomized
   -O, --org strings                The name of a GitHub organization. All repositories in that organization will be used.
   -o, --output string              The file that the output of the script should be outputted to. "-" means stdout. (default "-")
   -p, --platform string            The platform that is used. Available values: github, gitlab, gitea, bitbucket_server. (default "github")
@@ -628,7 +620,6 @@ Flags:
       --skip-pr                    Skip pull request and directly push to the branch.
   -s, --skip-repo strings          Skip changes on specified repositories, the name is including the owner of repository in the format "ownerName/repoName".
       --ssh-auth                   Use SSH cloning URL instead of HTTPS + token. This requires that a setup with ssh keys that have access to all repos and that the server is already in known_hosts.
-      --team-reviewers strings     Github team names of the reviewers, in format: 'org/team'
   -T, --token string               The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
       --topic strings              The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.
   -U, --user strings               The name of a user. All repositories owned by that user will be used.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ log-level: info
 # If this value is set, reviewers will be randomized.
 max-reviewers: 0
 
+# If this value is set, team reviewers will be randomized
+max-team-reviewers: 0
+
 # The name of a GitHub organization. All repositories in that organization will be used.
 org:
   - example
@@ -612,6 +615,7 @@ Flags:
       --log-format string          The formatting of the logs. Available values: text, json, json-pretty. (default "text")
   -L, --log-level string           The level of logging that should be made. Available values: trace, debug, info, error. (default "info")
   -M, --max-reviewers int          If this value is set, reviewers will be randomized.
+      --max-team-reviewers int     If this value is set, team reviewers will be randomized
   -O, --org strings                The name of a GitHub organization. All repositories in that organization will be used.
   -o, --output string              The file that the output of the script should be outputted to. "-" means stdout. (default "-")
   -p, --platform string            The platform that is used. Available values: github, gitlab, gitea, bitbucket_server. (default "github")

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -44,6 +44,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringSliceP("team-reviewers", "", nil, "Github team names of the reviewers, in format: 'org/team'")
 	cmd.Flags().StringSliceP("assignees", "a", nil, "The username of the assignees to be added on the pull request.")
 	cmd.Flags().IntP("max-reviewers", "M", 0, "If this value is set, reviewers will be randomized.")
+	cmd.Flags().IntP("max-team-reviewers", "", 0, "If this value is set, team reviewers will be randomized")
 	cmd.Flags().IntP("concurrent", "C", 1, "The maximum number of concurrent runs.")
 	cmd.Flags().BoolP("skip-pr", "", false, "Skip pull request and directly push to the branch.")
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
@@ -82,6 +83,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	reviewers, _ := flag.GetStringSlice("reviewers")
 	teamReviewers, _ := flag.GetStringSlice("team-reviewers")
 	maxReviewers, _ := flag.GetInt("max-reviewers")
+	maxTeamReviewers, _ := flag.GetInt("max-team-reviewers")
 	concurrent, _ := flag.GetInt("concurrent")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
 	skipRepository, _ := flag.GetStringSlice("skip-repo")
@@ -189,6 +191,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		Reviewers:        reviewers,
 		TeamReviewers:    teamReviewers,
 		MaxReviewers:     maxReviewers,
+		MaxTeamReviewers: maxTeamReviewers,
 		Interactive:      interactive,
 		DryRun:           dryRun,
 		Fork:             forkMode,

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -41,6 +41,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringP("pr-body", "b", "", "The body of the commit message. Will default to everything but the first line of the commit message if none is set.")
 	cmd.Flags().StringP("commit-message", "m", "", "The commit message. Will default to title + body if none is set.")
 	cmd.Flags().StringSliceP("reviewers", "r", nil, "The username of the reviewers to be added on the pull request.")
+	cmd.Flags().StringSliceP("team-reviewers", "", nil, "Github team names of the reviewers, in format: 'org/team'")
 	cmd.Flags().StringSliceP("assignees", "a", nil, "The username of the assignees to be added on the pull request.")
 	cmd.Flags().IntP("max-reviewers", "M", 0, "If this value is set, reviewers will be randomized.")
 	cmd.Flags().IntP("concurrent", "C", 1, "The maximum number of concurrent runs.")
@@ -79,6 +80,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	prBody, _ := flag.GetString("pr-body")
 	commitMessage, _ := flag.GetString("commit-message")
 	reviewers, _ := flag.GetStringSlice("reviewers")
+	teamReviewers, _ := flag.GetStringSlice("team-reviewers")
 	maxReviewers, _ := flag.GetInt("max-reviewers")
 	concurrent, _ := flag.GetInt("concurrent")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
@@ -185,6 +187,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		PullRequestTitle: prTitle,
 		PullRequestBody:  prBody,
 		Reviewers:        reviewers,
+		TeamReviewers:    teamReviewers,
 		MaxReviewers:     maxReviewers,
 		Interactive:      interactive,
 		DryRun:           dryRun,

--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -46,6 +46,7 @@ type Runner struct {
 	PullRequestTitle string
 	PullRequestBody  string
 	Reviewers        []string
+	TeamReviewers    []string
 	MaxReviewers     int // If set to zero, all reviewers will be used
 	DryRun           bool
 	CommitAuthor     *git.CommitAuthor
@@ -326,14 +327,15 @@ func (r *Runner) runSingleRepo(ctx context.Context, repo scm.Repository) (scm.Pu
 	} else {
 		log.Info("Creating pull request")
 		pr, err = r.VersionController.CreatePullRequest(ctx, repo, prRepo, scm.NewPullRequest{
-			Title:     r.PullRequestTitle,
-			Body:      r.PullRequestBody,
-			Head:      r.FeatureBranch,
-			Base:      baseBranch,
-			Reviewers: getReviewers(r.Reviewers, r.MaxReviewers),
-			Assignees: r.Assignees,
-			Draft:     r.Draft,
-			Labels:    r.Labels,
+			Title:         r.PullRequestTitle,
+			Body:          r.PullRequestBody,
+			Head:          r.FeatureBranch,
+			Base:          baseBranch,
+			Reviewers:     getReviewers(r.Reviewers, r.MaxReviewers),
+			TeamReviewers: r.TeamReviewers,
+			Assignees:     r.Assignees,
+			Draft:         r.Draft,
+			Labels:        r.Labels,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -47,7 +47,8 @@ type Runner struct {
 	PullRequestBody  string
 	Reviewers        []string
 	TeamReviewers    []string
-	MaxReviewers     int // If set to zero, all reviewers will be used
+	MaxReviewers     int // If set to zero, all reviewers will be use
+	MaxTeamReviewers int // If set to zero, all team-reviewers will be used
 	DryRun           bool
 	CommitAuthor     *git.CommitAuthor
 	BaseBranch       string // The base branch of the PR, use default branch if not set
@@ -332,7 +333,7 @@ func (r *Runner) runSingleRepo(ctx context.Context, repo scm.Repository) (scm.Pu
 			Head:          r.FeatureBranch,
 			Base:          baseBranch,
 			Reviewers:     getReviewers(r.Reviewers, r.MaxReviewers),
-			TeamReviewers: r.TeamReviewers,
+			TeamReviewers: getReviewers(r.TeamReviewers, r.MaxTeamReviewers),
 			Assignees:     r.Assignees,
 			Draft:         r.Draft,
 			Labels:        r.Labels,

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -337,7 +337,7 @@ func (g *Github) createPullRequest(ctx context.Context, repo repository, prRepo 
 }
 
 func (g *Github) addReviewers(ctx context.Context, repo repository, newPR scm.NewPullRequest, createdPR *github.PullRequest) error {
-	if len(newPR.Reviewers) == 0 {
+	if len(newPR.Reviewers) == 0 && len(newPR.TeamReviewers) == 0 {
 		return nil
 	}
 

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -340,9 +340,11 @@ func (g *Github) addReviewers(ctx context.Context, repo repository, newPR scm.Ne
 	if len(newPR.Reviewers) == 0 {
 		return nil
 	}
+
 	_, _, err := retry(ctx, func() (*github.PullRequest, *github.Response, error) {
 		return g.ghClient.PullRequests.RequestReviewers(ctx, repo.ownerName, repo.name, createdPR.GetNumber(), github.ReviewersRequest{
-			Reviewers: newPR.Reviewers,
+			Reviewers:     newPR.Reviewers,
+			TeamReviewers: newPR.TeamReviewers,
 		})
 	})
 	return err

--- a/internal/scm/pullrequest.go
+++ b/internal/scm/pullrequest.go
@@ -12,10 +12,11 @@ type NewPullRequest struct {
 	Head  string
 	Base  string
 
-	Reviewers []string // The username of all reviewers
-	Assignees []string
-	Draft     bool
-	Labels    []string
+	Reviewers     []string // The username of all reviewers
+	TeamReviewers []string // Teams to assign as reviewers
+	Assignees     []string
+	Draft         bool
+	Labels        []string
 }
 
 // PullRequestStatus is the status of a pull request, including statuses of the last commit

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -251,6 +251,7 @@ func TestTable(t *testing.T) {
 				"--author-email", "test@example.com",
 				"-m", "custom message",
 				"-r", "reviewer1,reviewer2",
+				"--team-reviewers", "team-1,team-2",
 				changerBinaryPath,
 			},
 			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
@@ -258,6 +259,8 @@ func TestTable(t *testing.T) {
 				assert.Len(t, vcMock.PullRequests[0].Reviewers, 2)
 				assert.Contains(t, vcMock.PullRequests[0].Reviewers, "reviewer1")
 				assert.Contains(t, vcMock.PullRequests[0].Reviewers, "reviewer2")
+				assert.Contains(t, vcMock.PullRequests[0].TeamReviewers, "team-1")
+				assert.Contains(t, vcMock.PullRequests[0].TeamReviewers, "team-2")
 			},
 		},
 
@@ -282,6 +285,30 @@ func TestTable(t *testing.T) {
 			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
 				require.Len(t, vcMock.PullRequests, 1)
 				assert.Len(t, vcMock.PullRequests[0].Reviewers, 2)
+			},
+		},
+
+		{
+			name: "random  team reviewers",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "should-change", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-m", "custom message",
+				"--team-reviewers", "team1,team2,team3",
+				"--max-team-reviewers", "2",
+				changerBinaryPath,
+			},
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				require.Len(t, vcMock.PullRequests, 1)
+				assert.Len(t, vcMock.PullRequests[0].TeamReviewers, 2)
 			},
 		},
 


### PR DESCRIPTION
# What does this change
_Give a summary of the change, and how it affects end-users. It's okay to copy/paste your commit messages._

Added support to assign github teams to pull requests using team `slug` (passed to the GH API).

```
go run main.go run $SCRIPT --config $CONFIG --token "$TOKEN"
INFO[0000] Running on 1 repositories                    
INFO[0000] Cloning and running script                    repo=marshmallow-insurance/{REPO}
INFO[0004] Pushing changes to remote                     repo=marshmallow-insurance/{REPO}
INFO[0005] Creating pull request                         repo=marshmallow-insurance/{REPO}
Repositories with a successful run:
  marshmallow-insurance/{REPO} #9
```

`$CONFIG` file here contains flag `team-reviewers` and `max-team-reviewers` and other repo related configs.

# What issue does it fix
Closes https://github.com/lindell/multi-gitter/discussions/328

# Notes for the reviewer

Let me know if we need to add further tests here.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
