### PR TITLE
ci: updated github actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,13 +5,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "^1.15.5"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
 
       - name: Build
         run: go build main.go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,12 +25,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,15 +5,15 @@ jobs:
     name: Test and Coverage
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "^1.15.5"
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "^1.15.5"
 
       - name: Prepare coverage
         run: mkdir coverage
@@ -22,12 +22,12 @@ jobs:
         run: SKIP_TYPES=time-dependent go test ./... -coverpkg=$( go list ./... | grep -v /tests | grep -v /tools | paste -sd "," -) -coverprofile coverage/coverage.out
 
       - name: Coverage convert
-        uses: jandelgado/gcov2lcov-action@v1.0.8
+        uses: jandelgado/gcov2lcov-action@v1.0.9
         with:
           infile: coverage/coverage.out
           outfile: coverage/lcov.info
 
       - name: Coveralls report
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,14 +10,14 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "^1.15.5"
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
 
       - name: Generate docs
         run: go run ./tools/docs/main.go

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:

--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -10,14 +10,14 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "^1.15.5"
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
 
       - name: Generate readme
         run: go run ./tools/readme-docs/main.go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,13 +16,13 @@ jobs:
           package-name: multi-gitter
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"dep","section":"Dependencies","hidden":false}]'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
         if: ${{ steps.release.outputs.release_created }}
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "^1.16.0"
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,24 +11,13 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "^1.15.5"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       # Because of a bug in go-git that that makes cloning of a folder in another Windows drive letter,
       # the test has to be moved and run in another folder on Windows (until the bug is fixed)


### PR DESCRIPTION
Node 12 is deprecated. Use only actions using node 16