### PR TITLE
refactor: combined repositories and pull requests in repocounter

### DIFF
--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -143,7 +143,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 
 		if pr != nil {
-			rc.AddSuccessPullRequest(pr)
+			rc.AddSuccessPullRequest(repos[i], pr)
 		} else {
 			rc.AddSuccessRepositories(repos[i])
 		}


### PR DESCRIPTION
Inspired by @raffis change in #369. A small refactor of the repo counter to not have both a repository and a pull request list.