### PR TITLE
feat: added --plain-output flag

### DIFF
--- a/internal/multigitter/repocounter/counter.go
+++ b/internal/multigitter/repocounter/counter.go
@@ -74,7 +74,7 @@ func (r *Counter) Info() string {
 			if errInfo.pullRequest == nil {
 				exitInfo += fmt.Sprintf("  %s\n", errInfo.repository.FullName())
 			} else {
-				if urler, ok := errInfo.pullRequest.(urler); ok {
+				if urler, hasURL := errInfo.pullRequest.(urler); hasURL && urler.URL() != "" {
 					exitInfo += fmt.Sprintf("  %s\n", terminal.Link(errInfo.pullRequest.String(), urler.URL()))
 				} else {
 					exitInfo += fmt.Sprintf("  %s\n", errInfo.pullRequest.String())
@@ -87,7 +87,7 @@ func (r *Counter) Info() string {
 		exitInfo += "Repositories with a successful run:\n"
 		for _, repo := range r.successRepositories {
 			if repo.pullRequest != nil {
-				if urler, ok := repo.pullRequest.(urler); ok {
+				if urler, hasURL := repo.pullRequest.(urler); hasURL && urler.URL() != "" {
 					exitInfo += fmt.Sprintf("  %s\n", terminal.Link(repo.pullRequest.String(), urler.URL()))
 				} else {
 					exitInfo += fmt.Sprintf("  %s\n", repo.pullRequest.String())

--- a/internal/multigitter/status.go
+++ b/internal/multigitter/status.go
@@ -25,7 +25,7 @@ func (s Statuser) Statuses(ctx context.Context) error {
 	}
 
 	for _, pr := range prs {
-		if urler, ok := pr.(urler); ok {
+		if urler, hasURL := pr.(urler); hasURL && urler.URL() != "" {
 			fmt.Fprintf(s.Output, "%s: %s\n", terminal.Link(pr.String(), urler.URL()), pr.Status())
 		} else {
 			fmt.Fprintf(s.Output, "%s: %s\n", pr.String(), pr.Status())

--- a/internal/multigitter/terminal/terminal.go
+++ b/internal/multigitter/terminal/terminal.go
@@ -2,13 +2,38 @@ package terminal
 
 import "fmt"
 
+// Printer formats things to the terminal
+type Printer struct {
+	Plain bool // Don't use terminal formatting
+}
+
+var DefaultPrinter = &Printer{}
+
 // Link generates a link in that can be displayed in the terminal
 // https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-func Link(text, url string) string {
+func (t *Printer) Link(text, url string) string {
+	if t.Plain {
+		return text
+	}
+
 	return fmt.Sprintf("\x1B]8;;%s\a%s\x1B]8;;\a", url, text)
 }
 
 // Bold generates a bold text for the terminal
-func Bold(text string) string {
+func (t *Printer) Bold(text string) string {
+	if t.Plain {
+		return text
+	}
+
 	return fmt.Sprintf("\033[1m%s\033[0m", text)
+}
+
+// Link generates a link in that can be displayed in the terminal using the default terminal printer
+func Link(text, url string) string {
+	return DefaultPrinter.Link(text, url)
+}
+
+// Bold generates a bold text for the terminal using the default terminal printer
+func Bold(text string) string {
+	return DefaultPrinter.Bold(text)
 }

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -977,6 +977,53 @@ Repositories with a successful run:
 		},
 
 		{
+			name: "formats urls",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "has-url", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-B", "custom-branch-name",
+				"-m", "custom message",
+				changerBinaryPath,
+			},
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				assert.Equal(t, "Repositories with a successful run:\n  \x1b]8;;https://github.com/owner/has-url/pull/1\aowner/has-url #1\x1b]8;;\a\n", runData.out)
+			},
+		},
+
+		{
+			name: "does not format urls when --plain-output is used",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "has-url", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-B", "custom-branch-name",
+				"-m", "custom message",
+				"--plain-output",
+				changerBinaryPath,
+			},
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				assert.Equal(t, `Repositories with a successful run:
+  owner/has-url #1
+`, runData.out)
+			},
+		},
+
+		{
 			name: "same feature and base branch name",
 			vcCreate: func(t *testing.T) *vcmock.VersionController {
 				return &vcmock.VersionController{

--- a/tests/vcmock/vcmock.go
+++ b/tests/vcmock/vcmock.go
@@ -197,6 +197,14 @@ func (pr PullRequest) String() string {
 	return fmt.Sprintf("%s #%d", pr.Repository.FullName(), pr.PRNumber)
 }
 
+func (pr PullRequest) URL() string {
+	if pr.Repository.RepoName == "has-url" {
+		return "https://github.com/owner/has-url/pull/1"
+	}
+
+	return ""
+}
+
 // Repository is a mock repository
 type Repository struct {
 	OwnerName string


### PR DESCRIPTION
# What does this change

Added the `--plain-output` option that ensures that output is not printed with terminal output and can be viewed as plain text.

# What issue does it fix
Closes #314 

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
