### PR TITLE
fix: panic when the PR branch is deleted

### DIFF
--- a/internal/scm/github/pullrequest.go
+++ b/internal/scm/github/pullrequest.go
@@ -21,7 +21,12 @@ func convertPullRequest(pr *github.PullRequest) pullRequest {
 }
 
 func convertGraphQLPullRequest(pr graphqlPR) pullRequest {
-	combinedStatus := pr.Commits.Nodes[0].Commit.StatusCheckRollup.State
+	var combinedStatus *graphqlPullRequestState
+	nodes := pr.Commits.Nodes
+	if len(nodes) > 0 {
+		combinedStatus = nodes[0].Commit.StatusCheckRollup.State
+	}
+
 	status := scm.PullRequestStatusUnknown
 
 	if pr.Merged {


### PR DESCRIPTION
# What does this change
In Github when the multi-gitter PR branch is deleted, `multi-gitter status` and `multi-gitter run` results in panic.

This PR addresses the issue.


# What issue does it fix
Closes https://github.com/lindell/multi-gitter/issues/384


# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
