### PR TITLE
feat: use repo search to select repositories

### DIFF
--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -28,6 +28,7 @@ func configurePlatform(cmd *cobra.Command) {
 	flags.StringSliceP("group", "G", nil, "The name of a GitLab organization. All repositories in that group will be used.")
 	flags.StringSliceP("user", "U", nil, "The name of a user. All repositories owned by that user will be used.")
 	flags.StringSliceP("repo", "R", nil, "The name, including owner of a GitHub repository in the format \"ownerName/repoName\".")
+	flags.StringP("repo-search", "", "", "Use a repository search to find repositories to target.")
 	flags.StringSliceP("topic", "", nil, "The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.")
 	flags.StringSliceP("project", "P", nil, "The name, including owner of a GitLab project in the format \"ownerName/repoName\".")
 	flags.BoolP("include-subgroups", "", false, "Include GitLab subgroups when using the --group flag.")
@@ -122,14 +123,15 @@ func createGithubClient(flag *flag.FlagSet, verifyFlags bool, readOnly bool) (mu
 	orgs, _ := flag.GetStringSlice("org")
 	users, _ := flag.GetStringSlice("user")
 	repos, _ := flag.GetStringSlice("repo")
+	repoSearch, _ := flag.GetString("repo-search")
 	topics, _ := flag.GetStringSlice("topic")
 	forkMode, _ := flag.GetBool("fork")
 	forkOwner, _ := flag.GetString("fork-owner")
 	sshAuth, _ := flag.GetBool("ssh-auth")
 	skipForks, _ := flag.GetBool("skip-forks")
 
-	if verifyFlags && len(orgs) == 0 && len(users) == 0 && len(repos) == 0 {
-		return nil, errors.New("no organization, user or repo set")
+	if verifyFlags && len(orgs) == 0 && len(users) == 0 && len(repos) == 0 && repoSearch == "" {
+		return nil, errors.New("no organization, user, repo or repo-search set")
 	}
 
 	token, err := getToken(flag)
@@ -164,11 +166,12 @@ func createGithubClient(flag *flag.FlagSet, verifyFlags bool, readOnly bool) (mu
 		BaseURL:             gitBaseURL,
 		TransportMiddleware: http.NewLoggingRoundTripper,
 		RepoListing: github.RepositoryListing{
-			Organizations: orgs,
-			Users:         users,
-			Repositories:  repoRefs,
-			Topics:        topics,
-			SkipForks:     skipForks,
+			Organizations:    orgs,
+			Users:            users,
+			Repositories:     repoRefs,
+			RepositorySearch: repoSearch,
+			Topics:           topics,
+			SkipForks:        skipForks,
 		},
 		MergeTypes:       mergeTypes,
 		ForkMode:         forkMode,

--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -28,7 +28,7 @@ func configurePlatform(cmd *cobra.Command) {
 	flags.StringSliceP("group", "G", nil, "The name of a GitLab organization. All repositories in that group will be used.")
 	flags.StringSliceP("user", "U", nil, "The name of a user. All repositories owned by that user will be used.")
 	flags.StringSliceP("repo", "R", nil, "The name, including owner of a GitHub repository in the format \"ownerName/repoName\".")
-	flags.StringP("repo-search", "", "", "Use a repository search to find repositories to target.")
+	flags.StringP("repo-search", "", "", "Use a repository search to find repositories to target (GitHub only). Forks are NOT included by default, use `fork:true` to include them. See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories")
 	flags.StringSliceP("topic", "", nil, "The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.")
 	flags.StringSliceP("project", "P", nil, "The name, including owner of a GitLab project in the format \"ownerName/repoName\".")
 	flags.BoolP("include-subgroups", "", false, "Include GitLab subgroups when using the --group flag.")

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -307,7 +307,7 @@ func (g *Github) getSearchRepositories(ctx context.Context, search string) ([]*g
 				return nil, nil, err
 			}
 
-			if rr.IncompleteResults != nil && *rr.IncompleteResults {
+			if rr.GetIncompleteResults() {
 				// can occur when search times out on the server: for now, fail instead
 				// of handling the issue
 				return nil, nil, fmt.Errorf("search timed out on GitHub and was marked incomplete: try refining the search to return fewer results or be less complex")

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -313,6 +313,10 @@ func (g *Github) getSearchRepositories(ctx context.Context, search string) ([]*g
 				return nil, nil, fmt.Errorf("search timed out on GitHub and was marked incomplete: try refining the search to return fewer results or be less complex")
 			}
 
+			if rr.GetTotal() > 1000 {
+				return nil, nil, fmt.Errorf("%d results for this search, but only the first 1000 results will be returned: try refining your search terms", rr.GetTotal())
+			}
+
 			return rr.Repositories, resp, nil
 		})
 

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -296,7 +296,11 @@ func (g *Github) getSearchRepositories(ctx context.Context, search string) ([]*g
 	i := 1
 	for {
 		rr, _, err := retry(ctx, func() ([]*github.Repository, *github.Response, error) {
-			rr, resp, err := g.ghClient.Search.Repositories(ctx, search, &github.SearchOptions{
+			// Include forks in the search: these are filtered if needed. We could
+			// filter in the search but this would not log that the fork had been
+			// skipped, which is different behaviour to the other types of retrieval.
+			query := "fork:true " + search
+			rr, resp, err := g.ghClient.Search.Repositories(ctx, query, &github.SearchOptions{
 				ListOptions: github.ListOptions{
 					Page:    i,
 					PerPage: 100,

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -214,7 +214,7 @@ func (g *Github) getRepositories(ctx context.Context) ([]*github.Repository, err
 		allRepos = append(allRepos, repo)
 	}
 
-	if len(g.RepositorySearch) > 0 {
+	if g.RepositorySearch != "" {
 		repos, err := g.getSearchRepositories(ctx, g.RepositorySearch)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not get repository search results for '%s'", g.RepositorySearch)

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -310,7 +310,7 @@ func (g *Github) getSearchRepositories(ctx context.Context, search string) ([]*g
 			if rr.IncompleteResults != nil && *rr.IncompleteResults {
 				// can occur when search times out on the server: for now, fail instead
 				// of handling the issue
-				return nil, nil, fmt.Errorf("search results incomplete")
+				return nil, nil, fmt.Errorf("search timed out on GitHub and was marked incomplete: try refining the search to return fewer results or be less complex")
 			}
 
 			return rr.Repositories, resp, nil

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -296,11 +296,7 @@ func (g *Github) getSearchRepositories(ctx context.Context, search string) ([]*g
 	i := 1
 	for {
 		rr, _, err := retry(ctx, func() ([]*github.Repository, *github.Response, error) {
-			// Include forks in the search: these are filtered if needed. We could
-			// filter in the search but this would not log that the fork had been
-			// skipped, which is different behaviour to the other types of retrieval.
-			query := "fork:true " + search
-			rr, resp, err := g.ghClient.Search.Repositories(ctx, query, &github.SearchOptions{
+			rr, resp, err := g.ghClient.Search.Repositories(ctx, search, &github.SearchOptions{
 				ListOptions: github.ListOptions{
 					Page:    i,
 					PerPage: 100,

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -364,3 +364,55 @@ func Test_GetSearchRepository_Incomplete(t *testing.T) {
 	assert.ErrorContains(t, err, "search timed out on GitHub and was marked incomplete")
 	assert.Len(t, repos, 0)
 }
+
+func Test_GetSearchRepository_TooManyResults(t *testing.T) {
+	transport := testTransport{
+		pathBodies: map[string]string{
+			"/search/repositories": `{
+					"total_count": 2054,
+					"incomplete_results": false,
+					"items": [
+					{
+						"id": 3,
+						"name": "search-repo1",
+						"full_name": "lindell/search-repo1",
+						"private": false,
+						"topics": [
+							"backend",
+							"go"
+						],
+						"owner": {
+							"login": "lindell",
+							"type": "User",
+							"site_admin": false
+						},
+						"html_url": "https://github.com/lindell/search-repo1",
+						"fork": true,
+						"archived": false,
+						"disabled": false,
+						"default_branch": "main",
+						"permissions": {
+							"admin": true,
+							"push": true,
+							"pull": true
+						},
+						"created_at": "2020-01-03T16:49:16Z"
+					}
+				]
+			}`,
+		},
+	}
+
+	gh, err := github.New(github.Config{
+		TransportMiddleware: transport.Wrapper,
+		RepoListing: github.RepositoryListing{
+			RepositorySearch: "search-string",
+		},
+		MergeTypes: []scm.MergeType{scm.MergeTypeMerge},
+	})
+	require.NoError(t, err)
+
+	repos, err := gh.GetRepositories(context.Background())
+	assert.ErrorContains(t, err, "only the first 1000 results will be returned")
+	assert.Len(t, repos, 0)
+}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -312,3 +312,55 @@ func Test_GetRepositories(t *testing.T) {
 		}
 	}
 }
+
+func Test_GetSearchRepository_Incomplete(t *testing.T) {
+	transport := testTransport{
+		pathBodies: map[string]string{
+			"/search/repositories": `{
+					"total_count": 1,
+					"incomplete_results": true,
+					"items": [
+					{
+						"id": 3,
+						"name": "search-repo1",
+						"full_name": "lindell/search-repo1",
+						"private": false,
+						"topics": [
+							"backend",
+							"go"
+						],
+						"owner": {
+							"login": "lindell",
+							"type": "User",
+							"site_admin": false
+						},
+						"html_url": "https://github.com/lindell/search-repo1",
+						"fork": true,
+						"archived": false,
+						"disabled": false,
+						"default_branch": "main",
+						"permissions": {
+							"admin": true,
+							"push": true,
+							"pull": true
+						},
+						"created_at": "2020-01-03T16:49:16Z"
+					}
+				]
+			}`,
+		},
+	}
+
+	gh, err := github.New(github.Config{
+		TransportMiddleware: transport.Wrapper,
+		RepoListing: github.RepositoryListing{
+			RepositorySearch: "search-string",
+		},
+		MergeTypes: []scm.MergeType{scm.MergeTypeMerge},
+	})
+	require.NoError(t, err)
+
+	repos, err := gh.GetRepositories(context.Background())
+	assert.ErrorContains(t, err, "search timed out on GitHub and was marked incomplete")
+	assert.Len(t, repos, 0)
+}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -90,7 +90,7 @@ func Test_GetRepositories(t *testing.T) {
 					"push": true,
 					"pull": true
 				},
-				"created_at": "2020-01-02T16:49:16Z"
+				"created_at": "2020-01-02T16:49:17Z"
 			}`,
 			"/users/test-user/repos": `[
 				{
@@ -117,7 +117,7 @@ func Test_GetRepositories(t *testing.T) {
 						"push": true,
 						"pull": true
 					},
-					"created_at": "2020-01-03T16:49:16Z"
+					"created_at": "2020-01-03T16:49:18Z"
 				}
 			]`,
 			"/search/repositories": `{
@@ -148,7 +148,7 @@ func Test_GetRepositories(t *testing.T) {
 							"push": true,
 							"pull": true
 						},
-						"created_at": "2020-01-03T16:49:16Z"
+						"created_at": "2020-01-03T16:49:19Z"
 					}
 				]
 			}`,


### PR DESCRIPTION
# What does this change

Using the `--repo-search` option, it is possible to supply a GitHub **repository** search query that is used to generate the set of repositories to process.

This feature is GItHub-only at the moment.

This allows for searches that reference:

- partial names with boolean queries: `owner:buildkite-plugins in:name docker AND plugin`
- one or multiple owners `owner:cultureamp owner:jamestelfer fork:true in:name plugin`
- README contents
- license

I initially started this as a "warm up" to implementing something similar with code search, but the partial name search and license search are potentially quite useful in themselves.

Obviously this means that search syntax and results depend on the underlying source being queried, so implementations for GitLab et al would be required to see this feature properly take root.

References:

- [GitHub repository search API](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-repositories)
- [GitHub repo search qualifiers](https://docs.github.com/articles/searching-for-repositories/)
- [GitHub search query syntax](https://docs.github.com/rest/search/search#constructing-a-search-query) (this is the legacy search, as the API does not yet use the new search engine).

```console
$ multi-gitter run examples/general/test.sh --repo-search "user:jamestelfer fork:only" --dry-run --commit-message "chore: foo"

<log output elided />
INFO[0102] Cloning and running script                    repo=jamestelfer/multi-gitter
INFO[0103] Script output: jamestelfer/multi-gitter       repo=jamestelfer/multi-gitter
DEBU[0103] diff --git a/.features.yaml b/.features.yaml
new file mode 100644
index 0000000000000000000000000000000000000000..73311e25f5ad0766cd0576c7302b96f9bc76a4b7
--- /dev/null
+++ b/.features.yaml
@@ -0,0 +1,3 @@
+
+features: ~
+
INFO[0103] Skipping pushing changes because of dry run   repo=jamestelfer/multi-gitter
Repositories with a successful run:
  jamestelfer/jenkins-inheritance-plugin #0
  jamestelfer/slow-cheetah.xdt #0
  jamestelfer/global-build-stats-plugin #0
  jamestelfer/wheel-of-misfortune #0
  jamestelfer/blast-1 #0
  jamestelfer/cloudformation-cli #0
  jamestelfer/step-templates-buildkite-plugin #0
  jamestelfer/fusionauth-site #0
  jamestelfer/aws-lambda-go #0
  jamestelfer/testza #0
  jamestelfer/avro #0
  jamestelfer/ca-go #0
  jamestelfer/rocketcrab #0
  jamestelfer/terraform-cdk #0
  jamestelfer/aws-cdk #0
  jamestelfer/multi-gitter #0
```

# What issue does it fix

Closes #398

Refer also to [original discussion](https://github.com/lindell/multi-gitter/discussions/386).

# Notes for the reviewer

Happy for feedback/changes of direction.

# Checklist
- [X] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
