### PR TITLE
ci: turn on renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "dependencyDashboard": true,
     "enabledManagers": [
         "gomod"
     ],


### PR DESCRIPTION
# What does this change
Turns on the Renovate [dependency dashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard) to make it easier to see what updates could be made. Also, it adds the JSON schema for the Renovate config format.