### PR TITLE
ci: reduce Github Action permissions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,7 @@
 name: Testing Coverage
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     name: Test and Coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed for release-please
+      issues: write # needed for github-release-commenter
       pull-requests: write # needed for release-please and github-release-commenter
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3.7.10
@@ -47,7 +48,6 @@ jobs:
         uses: apexskier/github-release-commenter@v1.3.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          comment-template:
-            Included in release {release_link} 🎉
+          comment-template: Included in release {release_link} 🎉
           skip-label: "autorelease: tagged,autorelease: pending"
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,16 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 name: release
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for release-please
+      pull-requests: write # needed for release-please and github-release-commenter
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3.7.10
         id: release


### PR DESCRIPTION
# What does this change

Reduces permissions for the Github Actions in the two workflows that had yet to get explicit permissions set.

I'm not entirely sure what permissions Coveralls require, it seems they have not documented it. So, we can see if it runs fine with the given permissions or not. _Update: It was successful and uploaded the coverage._ 👍 

For the release workflow, I think the permissions are enough. But it was not completely documented for the commenter action. From what I can see in the [source code](https://github.com/apexskier/github-release-commenter), the Github calls are: lists releases (`contents: read`), compare commits (`contents: read`), comments and labels on linked issues/prs (`issues: write` and `pull-requests: write`), there's also a graphql query that I think should fly with the other permissions.

# What issue does it fix

This is a continuation on: https://github.com/lindell/multi-gitter/pull/410
