### PR TITLE
ci: migrate renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,10 @@
             "security"
         ]
     },
-    "stabilityDays": 3,
+    "minimumReleaseAge": "3 days",
     "packageRules": [
         {
-            "updateTypes": [
+            "matchUpdateTypes": [
                 "minor",
                 "patch",
                 "digest"
@@ -26,7 +26,7 @@
             ]
         },
         {
-            "updateTypes": [
+            "matchUpdateTypes": [
                 "major"
             ],
             "schedule": [


### PR DESCRIPTION
# What does this change
Migrates the Renovate config to the current standard. I used the [`renovate-config-validator`](https://docs.renovatebot.com/config-validation/) command provided with `renovate@37` for the migration.