### PR TITLE
ci: renovate should maintain github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,8 @@
     ],
     "github-actions": {
         "enabled": true,
-        "pinDigests": true
+        "pinDigests": true,
+        "semanticCommitType": "ci"
     },
     "gomod": {
         "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "dependencyDashboard": true,
     "enabledManagers": [
+        "github-actions",
         "gomod"
     ],
     "semanticCommitType": "dep",
@@ -14,6 +15,37 @@
     "minimumReleaseAge": "3 days",
     "packageRules": [
         {
+            "description": "Update non-major Github Actions releases monthly in group",
+            "groupName": "all non-major Github Actions",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "pinDigest",
+                "digest"
+            ],
+            "schedule": [
+                "on the first day of the month also on the 2nd day of the month before 5pm"
+            ]
+        },
+        {
+            "description": "Require an approval for major Github Actions releases",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "dependencyDashboardApproval": true
+        },
+        {
+            "description": "Update non-major Go modules releases monthly and merge automatically",
+            "matchManagers": [
+                "gomod"
+            ],
             "matchUpdateTypes": [
                 "minor",
                 "patch",
@@ -26,6 +58,10 @@
             ]
         },
         {
+            "description": "Update major Go modules releases monthly",
+            "matchManagers": [
+                "gomod"
+            ],
             "matchUpdateTypes": [
                 "major"
             ],
@@ -40,6 +76,10 @@
         "gomodUpdateImportPaths",
         "gomodTidy"
     ],
+    "github-actions": {
+        "enabled": true,
+        "pinDigests": true
+    },
     "gomod": {
         "enabled": true
     }


### PR DESCRIPTION
# What does this change

This PR was based on the branch in https://github.com/lindell/multi-gitter/pull/417, so it has been rebased after that PR had been merged.

Adds Renovate config for maintaining Github Actions versions. It groups non-major Github Actions releases and update them monthly, while major releases require an approval on the Dependency Dashboard.

The package rules for Go modules are refined to specify that they are only for the `"gomod"` manager. And descriptions are added as well, to get a human readable description.
