### PR TITLE
fix: cmdgit BranchExist should match full branch name

### DIFF
--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -126,7 +126,7 @@ func (g *Git) BranchExist(remoteName, branchName string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return strings.Contains(stdOut, fmt.Sprintf("refs/heads/%s", branchName)), nil
+	return strings.Contains(stdOut, fmt.Sprintf("\trefs/heads/%s\n", branchName)), nil
 }
 
 // Push the committed changes to the remote


### PR DESCRIPTION
# What does this change

Makes `BranchExist` in `cmdgit` match the full branch name. Previously, it would incorrectly return `true` if an existing branch started with the same name as the configured branch in `multi-gitter`. 

# Notes for the reviewer
Added the test prior to implementing the fix and without the fix the test failed (as expected) when running with `--git-type cmd`.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
