### PR TITLE
Feature #454 - Add --push-only flag to allow developers to only push the feature branch

### DIFF
--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -48,6 +48,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().IntP("max-team-reviewers", "", 0, "If this value is set, team reviewers will be randomized")
 	cmd.Flags().IntP("concurrent", "C", 1, "The maximum number of concurrent runs.")
 	cmd.Flags().BoolP("skip-pr", "", false, "Skip pull request and directly push to the branch.")
+	cmd.Flags().BoolP("push-only", "", false, "Skip pull request and only push the feature branch.")
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
 	cmd.Flags().BoolP("interactive", "i", false, "Take manual decision before committing any change. Requires git to be installed.")
 	cmd.Flags().BoolP("dry-run", "d", false, "Run without pushing changes or creating pull requests.")
@@ -89,6 +90,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	maxTeamReviewers, _ := flag.GetInt("max-team-reviewers")
 	concurrent, _ := flag.GetInt("concurrent")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
+	pushOnly, _ := flag.GetBool("push-only")
 	skipRepository, _ := flag.GetStringSlice("skip-repo")
 	interactive, _ := flag.GetBool("interactive")
 	dryRun, _ := flag.GetBool("dry-run")
@@ -127,6 +129,10 @@ func run(cmd *cobra.Command, _ []string) error {
 		if prBody == "" && len(split) == 2 {
 			prBody = split[1]
 		}
+	}
+
+	if skipPullRequest && pushOnly {
+		return errors.New("--push-only and --skip-pr can't be used at the same time")
 	}
 
 	if skipPullRequest && forkMode {
@@ -228,6 +234,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		Fork:                   forkMode,
 		ForkOwner:              forkOwner,
 		SkipPullRequest:        skipPullRequest,
+		PushOnly:               pushOnly,
 		SkipRepository:         skipRepository,
 		CommitAuthor:           commitAuthor,
 		BaseBranch:             baseBranchName,

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -131,6 +131,10 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if pushOnly && forkMode {
+		return errors.New("--push-only and --fork can't be used at the same time")
+	}
+
 	if skipPullRequest && pushOnly {
 		return errors.New("--push-only and --skip-pr can't be used at the same time")
 	}

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -1186,6 +1186,76 @@ Repositories with a successful run:
 				assert.Equal(t, "Both the feature branch and base branch was named master, if you intended to push directly into the base branch, please use the `skip-pr` option:\n  owner/should-not-change\n", runData.out)
 			},
 		},
+
+		{
+			name: "fork conflicts with pushOnly",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "example-repository", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-B", "custom-branch-name",
+				"-m", "custom message",
+				"--fork", "--push-only",
+				changerBinaryPath,
+			},
+			expectErr: true,
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				assert.Contains(t, runData.cmdOut, "Error: --push-only and --fork can't be used at the same time")
+			},
+		},
+		{
+			name: "skipPr conflicts with pushOnly",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "example-repository", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-B", "custom-branch-name",
+				"-m", "custom message",
+				"--skip-pr", "--push-only",
+				changerBinaryPath,
+			},
+			expectErr: true,
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				assert.Contains(t, runData.cmdOut, "Error: --push-only and --skip-pr can't be used at the same time")
+			},
+		},
+		{
+			name: "pushOnly success",
+			vcCreate: func(t *testing.T) *vcmock.VersionController {
+				return &vcmock.VersionController{
+					Repositories: []vcmock.Repository{
+						createRepo(t, "owner", "example-repository", "i like apples"),
+					},
+				}
+			},
+			args: []string{
+				"run",
+				"--author-name", "Test Author",
+				"--author-email", "test@example.com",
+				"-B", "custom-branch-name",
+				"-m", "custom message",
+				"--push-only",
+				changerBinaryPath,
+			},
+			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
+				assert.Equal(t, runData.cmdOut, "")
+				assert.Equal(t, runData.out, "Repositories with a successful run:\n  owner/example-repository #0\n")
+			},
+		},
 	}
 
 	for _, gitBackend := range gitBackends {


### PR DESCRIPTION
 - Add --push-only flag to only push a feature branch

# What does this change
This feature adds a flag named --push-only to the run command which will allow developers to create feature branches without creating PRs.

# What issue does it fix
Closes #454 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
