### PR TITLE
feat(github): Update existing draft PR to Ready For Review

### DIFF
--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -580,6 +580,7 @@ func (g *Github) UpdatePullRequest(ctx context.Context, repo scm.Repository, pul
 		return g.ghClient.PullRequests.Edit(ctx, pr.ownerName, pr.repoName, pr.number, &github.PullRequest{
 			Title: &updatedPR.Title,
 			Body:  &updatedPR.Body,
+			Draft: &updatedPR.Draft,
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
# What does this change

When an existing PR exists and the `--draft` flag is not present in the run command, update the existing PR from "Draft" to "Ready For Review"

# What issue does it fix
Closes #455.

# Notes for the reviewer
I noticed this issue, and figured I would want to use it in some upcoming work I want to do. And I figured this is the one line change that you mentioned in https://github.com/lindell/multi-gitter/issues/455#issuecomment-1943135570. I saw that this already exists for the [Gitea](https://github.com/KasonBraley/multi-gitter/blob/7c252760299448dade4ce1cf226f76adac51e931/internal/scm/gitea/gitea.go#L353-L355) and [GitLab](https://github.com/KasonBraley/multi-gitter/blob/7c252760299448dade4ce1cf226f76adac51e931/internal/scm/gitlab/gitlab.go#L320-L322) implementations.  Let me know if there are any tests or anything else specific you'd like to see and I can try to figure that out.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added
