### PR TITLE
Accept capital chars in run command

### DIFF
--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sync"
 	"syscall"
+	"unicode"
 
 	"github.com/eiannone/keyboard"
 	"github.com/lindell/multi-gitter/internal/git"
@@ -420,7 +421,7 @@ func (r *Runner) interactive(dir string, repo scm.Repository) error {
 			return errRejected
 		}
 
-		switch char {
+		switch unicode.ToLower(char) {
 		case 'v':
 			fmt.Println("Showing changes...")
 			cmd := exec.Command("git", "diff", "HEAD~1")


### PR DESCRIPTION
# What does this change
The intractive usage says:
```
var interactiveInfo = `(V)iew changes. (A)ccept or (R)eject`
```

I was confused about it, and actually tried to press Shift+V.
Let's accept both lower and upprt case keys.

# Checklist
- [X] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] Tests if something new is added
