### PR TITLE
chore: fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ brews:
     description: "Update multiple repositories in bulk"
     homepage: https://github.com/lindell/multi-gitter
     license: "Apache-2.0"
-    folder: Formula
+    directory: Formula
     install: |-
       bin.install "multi-gitter"
       bash_completion.install "completions/multi-gitter.bash" => "multi-gitter"


### PR DESCRIPTION
- **chore(goreleaser): set `version: 2`**
- **chore(goreleaser): replace brews.foloder with brews.directory**

# What does this change
_Give a summary of the change, and how it affects end-users. It's okay to copy/paste your commit messages._

_For example if it introduces a new flag or modifies a commands output, give an example of you running the command and showing real output here._

Fixed GoReleaser config's errors.

https://github.com/lindell/multi-gitter/actions/runs/9755716855/job/26924701362

```
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```

The release of v0.52.1 failed, so this pull request fixes the error.

Furthermore, this pull request fixes another error too.

```console
$ goreleaser check
  ⨯ command failed                                   error=yaml: unmarshal errors:
  line 76: field folder not found in type config.Homebrew
```

https://goreleaser.com/deprecations/#brewsfolder

# What issue does it fix
Closes # _(issue)_

_If there is not an existing issue, please make sure we have context on why this change is needed. ._

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
