### PR TITLE
Add support for signed commits through the Github API

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,6 @@ token:
 topic:
   - example
 
-# Attempt to commit and push through the Github API, rather than pushing through the git client.
-use-gh-api: false
-
 # The name of a user. All repositories owned by that user will be used.
 user:
   - example
@@ -702,7 +699,6 @@ Flags:
       --team-reviewers strings     Github team names of the reviewers, in format: 'org/team'
   -T, --token string               The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
       --topic strings              The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.
-      --use-gh-api                 Attempt to commit and push through the Github API, rather than pushing through the git client.
   -U, --user strings               The name of a user. All repositories owned by that user will be used.
   -u, --username string            The Bitbucket server username.
 ```

--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ token:
 topic:
   - example
 
+# Attempt to commit and push through the Github API, rather than pushing through the git client.
+use-gh-api: false
+
 # The name of a user. All repositories owned by that user will be used.
 user:
   - example

--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ token:
 topic:
   - example
 
+# Attempt to commit and push through the Github API, rather than pushing through the git client.
+use-gh-api: false
+
 # The name of a user. All repositories owned by that user will be used.
 user:
   - example
@@ -699,6 +702,7 @@ Flags:
       --team-reviewers strings     Github team names of the reviewers, in format: 'org/team'
   -T, --token string               The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
       --topic strings              The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.
+      --use-gh-api                 Attempt to commit and push through the Github API, rather than pushing through the git client.
   -U, --user strings               The name of a user. All repositories owned by that user will be used.
   -u, --username string            The Bitbucket server username.
 ```

--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ Flags:
       --team-reviewers strings     Github team names of the reviewers, in format: 'org/team'
   -T, --token string               The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.
       --topic strings              The topic of a GitHub/GitLab/Gitea repository. All repositories having at least one matching topic are targeted.
+      --use-gh-api                 Attempt to commit and push through the Github API, rather than pushing through the git client.
   -U, --user strings               The name of a user. All repositories owned by that user will be used.
   -u, --username string            The Bitbucket server username.
 ```

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -61,6 +61,7 @@ Available values:
 	_ = cmd.RegisterFlagCompletionFunc("conflict-strategy", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"skip", "replace"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	cmd.Flags().BoolP("use-gh-api", "", false, "Attempt to commit and push through the Github API, rather than pushing through the git client.")
 	cmd.Flags().StringSliceP("labels", "", nil, "Labels to be added to any created pull request.")
 	cmd.Flags().StringP("author-name", "", "", "Name of the committer. If not set, the global git config setting will be used.")
 	cmd.Flags().StringP("author-email", "", "", "Email of the committer. If not set, the global git config setting will be used.")
@@ -92,6 +93,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	concurrent, _ := flag.GetInt("concurrent")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
 	pushOnly, _ := flag.GetBool("push-only")
+	useGHAPI, _ := flag.GetBool("use-gh-api")
 	skipRepository, _ := flag.GetStringSlice("skip-repo")
 	interactive, _ := flag.GetBool("interactive")
 	dryRun, _ := flag.GetBool("dry-run")
@@ -241,6 +243,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		ForkOwner:              forkOwner,
 		SkipPullRequest:        skipPullRequest,
 		PushOnly:               pushOnly,
+		UseGHAPI:               useGHAPI,
 		SkipRepository:         skipRepository,
 		CommitAuthor:           commitAuthor,
 		BaseBranch:             baseBranchName,

--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -149,3 +149,15 @@ func (g *Git) AddRemote(name, url string) error {
 	_, err := g.run(cmd)
 	return err
 }
+
+func (g *Git) Additions() map[string]string {
+	return make(map[string]string)
+}
+
+func (g *Git) Deletions() []string {
+	return make([]string, 0)
+}
+
+func (g *Git) OldHash() string {
+	return ""
+}

--- a/internal/multigitter/shared.go
+++ b/internal/multigitter/shared.go
@@ -34,6 +34,9 @@ type Git interface {
 	BranchExist(remoteName, branchName string) (bool, error)
 	Push(ctx context.Context, remoteName string, force bool) error
 	AddRemote(name, url string) error
+	Additions() map[string]string
+	Deletions() []string
+	OldHash() string
 }
 
 type stackTracer interface {

--- a/internal/scm/github/graphql_commit.go
+++ b/internal/scm/github/graphql_commit.go
@@ -1,0 +1,271 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (g *Github) CommitAndPushThoughGraphQL(ctx context.Context,
+	headline string,
+	featureBranch string,
+	cloneURL string,
+	oldHash string,
+	additions map[string]string,
+	deletions []string,
+	forcePush bool,
+	branchExist bool) error {
+	array := strings.Split(cloneURL, "/")
+
+	repositoryName := strings.Trim(array[len(array)-1], ".git")
+	owner := array[len(array)-2]
+
+	if forcePush {
+		fmt.Printf("about to get branchid\n")
+
+		branchID, err := g.getBranchID(ctx, owner, repositoryName, featureBranch)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("about to deleteref\n")
+
+		err = g.deleteRef(ctx, branchID)
+		if err != nil {
+			return err
+		}
+
+		branchExist = false
+	}
+
+	if !branchExist {
+		fmt.Printf("about to create branch\n")
+
+		err := g.CreateBranch(ctx, owner,
+			repositoryName,
+			featureBranch,
+			oldHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("About to commit though API\n")
+
+	err := g.CommitThroughAPI(ctx, owner, repositoryName, featureBranch, oldHash, headline, additions, deletions)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Github) getRepositoryID(ctx context.Context, owner string, name string) (string, error) {
+	query := `query($owner: String!, $name: String!) {
+		repository(owner: $owner, name: $name) {
+			id
+		} 
+	}`
+
+	var result getRepositoryOutput
+
+	err := g.makeGraphQLRequest(ctx, query, &RepositoryInput{Name: name, Owner: owner}, &result)
+
+	if err != nil {
+		return "", err
+	}
+
+	return result.Repository.ID, nil
+}
+
+func (g *Github) getBranchID(ctx context.Context, owner string, repoName string, branchName string) (string, error) {
+	query := `query($owner: String!, $name: String!) {
+		repository(owner: $owner, name: $name) {
+			refs(first: 100, refPrefix: "refs/heads/") {
+				edges {
+					node {
+						id
+						name
+					}
+				}
+			}
+		} 
+	}`
+
+	var result getRefsOutput
+
+	err := g.makeGraphQLRequest(ctx, query, &RepositoryInput{Name: repoName, Owner: owner}, &result)
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, edge := range result.Repository.Refs.Edges {
+		if edge.Node.Name == branchName {
+			return edge.Node.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find branch named %s to delete", branchName)
+}
+
+func (g *Github) CreateBranch(ctx context.Context, owner string, repoName string, branchName string, oid string) error {
+	query := `mutation($input: CreateRefInput!){
+		createRef(input: $input) {
+			ref {
+				name
+			}
+		}
+	}`
+
+	var cri CreateRefInput
+
+	repoID, err := g.getRepositoryID(ctx, owner, repoName)
+
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(repoName, "refs/heads/") {
+		cri.Input.Name = "refs/heads/" + branchName
+	} else {
+		cri.Input.Name = branchName
+	}
+
+	cri.Input.Oid = oid
+	cri.Input.RepositoryID = repoID
+
+	var result interface{}
+
+	err = g.makeGraphQLRequest(ctx, query, cri, &result)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Github) CommitThroughAPI(ctx context.Context, owner string, repoName string, branch string, oid string, headline string, additions map[string]string, deletions []string) error {
+	query := `
+		mutation ($input: CreateCommitOnBranchInput!) {
+			createCommitOnBranch(input: $input) {
+				commit {
+				url
+				}
+			}
+		}`
+
+	var v createCommitOnBranchInput
+
+	v.Input.Branch.RepositoryNameWithOwner = owner + "/" + repoName
+
+	v.Input.Branch.BranchName = branch
+	v.Input.ExpectedHeadOid = oid
+	v.Input.Message.Headline = headline
+
+	for path, contents := range additions {
+		v.Input.FileChanges.Additions = append(v.Input.FileChanges.Additions, struct {
+			Path     string "json:\"path,omitempty\""
+			Contents string "json:\"contents,omitempty\""
+		}{Path: path, Contents: contents})
+	}
+
+	for _, path := range deletions {
+		v.Input.FileChanges.Deletions = append(v.Input.FileChanges.Deletions, struct {
+			Path string "json:\"path,omitempty\""
+		}{Path: path})
+	}
+
+	var result map[string]interface{}
+
+	err := g.makeGraphQLRequest(ctx, query, v, &result)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Github) deleteRef(ctx context.Context, branchRef string) error {
+	query := `mutation($input: DeleteRefInput!){
+		deleteRef(input: $input){
+    		clientMutationId
+  		}
+	}`
+
+	var deleteRefInput DeleteRefInput
+	deleteRefInput.Input.RefID = branchRef
+
+	type ignoreReturn map[string]interface{}
+
+	err := g.makeGraphQLRequest(ctx, query, deleteRefInput, &ignoreReturn{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type createCommitOnBranchInput struct {
+	Input struct {
+		ExpectedHeadOid string `json:"expectedHeadOid"`
+		Branch          struct {
+			RepositoryNameWithOwner string `json:"repositoryNameWithOwner"`
+			BranchName              string `json:"branchName"`
+		} `json:"branch"`
+		Message struct {
+			Headline string `json:"headline"`
+		} `json:"message"`
+		FileChanges struct {
+			Additions []struct {
+				Path     string `json:"path,omitempty"`
+				Contents string `json:"contents,omitempty"`
+			} `json:"additions"`
+			Deletions []struct {
+				Path string `json:"path,omitempty"`
+			} `json:"deletions"`
+		} `json:"fileChanges"`
+	} `json:"input"`
+}
+
+type CreateRefInput struct {
+	Input struct {
+		Name         string `json:"name"`
+		Oid          string `json:"oid"`
+		RepositoryID string `json:"repositoryId"`
+	} `json:"input"`
+}
+
+type RepositoryInput struct {
+	Name  string `json:"name"`
+	Owner string `json:"owner"`
+}
+
+type DeleteRefInput struct {
+	Input struct {
+		RefID string `json:"refId"`
+	} `json:"input"`
+}
+
+type getRepositoryOutput struct {
+	Repository struct {
+		ID string `json:"id"`
+	} `json:"repository"`
+}
+
+type getRefsOutput struct {
+	Repository struct {
+		Refs struct {
+			Edges []struct {
+				Node struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"node"`
+			} `json:"edges"`
+		} `json:"refs"`
+	} `json:"repository"`
+}

--- a/internal/scm/github/graphql_commit.go
+++ b/internal/scm/github/graphql_commit.go
@@ -21,14 +21,10 @@ func (g *Github) CommitAndPushThoughGraphQL(ctx context.Context,
 	owner := array[len(array)-2]
 
 	if forcePush {
-		fmt.Printf("about to get branchid\n")
-
 		branchID, err := g.getBranchID(ctx, owner, repositoryName, featureBranch)
 		if err != nil {
 			return err
 		}
-
-		fmt.Printf("about to deleteref\n")
 
 		err = g.deleteRef(ctx, branchID)
 		if err != nil {
@@ -39,8 +35,6 @@ func (g *Github) CommitAndPushThoughGraphQL(ctx context.Context,
 	}
 
 	if !branchExist {
-		fmt.Printf("about to create branch\n")
-
 		err := g.CreateBranch(ctx, owner,
 			repositoryName,
 			featureBranch,
@@ -49,8 +43,6 @@ func (g *Github) CommitAndPushThoughGraphQL(ctx context.Context,
 			return err
 		}
 	}
-
-	fmt.Printf("About to commit though API\n")
 
 	err := g.CommitThroughAPI(ctx, owner, repositoryName, featureBranch, oldHash, headline, additions, deletions)
 


### PR DESCRIPTION
# What does this change
_Give a summary of the change, and how it affects end-users. It's okay to copy/paste your commit messages._

This PR adds the ability to commit through the Github API, rather than through the git client. This creates a signed commit for both user accounts, and for Github Apps.

_For example if it introduces a new flag or modifies a commands output, give an example of you running the command and showing real output here._
```./bin/test-gitter-local run -R scorebet/managed-actions --branch test2235 --pr-title "test" --conflict-strategy replace --commit-message "This changed" --use-gh-api scripts/test.sh
INFO[0000] Running on 1 repositories                    
INFO[0000] Cloning and running script                    repo=scorebet/managed-actions
INFO[0004] Pushing changes to remote                     repo=scorebet/managed-actions
INFO[0005] Creating pull request                         repo=scorebet/managed-actions
Repositories with a successful run:
  scorebet/managed-actions #26```

# What issue does it fix
Closes #261 

_If there is not an existing issue, please make sure we have context on why this change is needed. ._

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

I'm checking to see if this PR is sane. I'm not sure if commit signing is available using a Github User, but Github Applications need to commit though the Github API in order to get signed commits. There is a fairly decent write up for this issue [here](https://github.com/Nautilus-Cyberneering/pygithub/blob/main/docs/how_to_sign_automatic_commits_in_github_actions.md)

Committing through the API is guaranteed to create a signed commit, so it removes all ambiguity 

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added ( I will happily add test cases if you are okay with the general approach)
