### PR TITLE
fix: print most things to stderr instead of stdout

### DIFF
--- a/cmd/cmd-print.go
+++ b/cmd/cmd-print.go
@@ -87,7 +87,7 @@ func printCMD(cmd *cobra.Command, _ []string) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		fmt.Println("Finishing up ongoing runs. Press CTRL+C again to abort now.")
+		fmt.Fprintln(os.Stderr, "Finishing up ongoing runs. Press CTRL+C again to abort now.")
 		cancel()
 		<-c
 		os.Exit(1)
@@ -110,7 +110,7 @@ func printCMD(cmd *cobra.Command, _ []string) error {
 
 	err = printer.Print(ctx)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -211,7 +211,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		fmt.Println("Finishing up ongoing runs. Press CTRL+C again to abort now.")
+		fmt.Fprintln(os.Stderr, "Finishing up ongoing runs. Press CTRL+C again to abort now.")
 		cancel()
 		<-c
 		os.Exit(1)
@@ -257,7 +257,7 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	err = runner.Run(ctx)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 

--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -403,8 +403,8 @@ func (r *Runner) ensurePullRequestExists(ctx context.Context, log log.FieldLogge
 var interactiveInfo = `(V)iew changes. (A)ccept or (R)eject`
 
 func (r *Runner) interactive(dir string, repo scm.Repository) error {
-	fmt.Printf("Changes were made to %s\n", terminal.Bold(repo.FullName()))
-	fmt.Println(interactiveInfo)
+	fmt.Fprintf(os.Stderr, "Changes were made to %s\n", terminal.Bold(repo.FullName()))
+	fmt.Fprintln(os.Stderr, interactiveInfo)
 	for {
 		char, key, err := keyboard.GetSingleKey()
 		if err != nil {
@@ -423,12 +423,12 @@ func (r *Runner) interactive(dir string, repo scm.Repository) error {
 
 		switch unicode.ToLower(char) {
 		case 'v':
-			fmt.Println("Showing changes...")
+			fmt.Fprintln(os.Stderr, "Showing changes...")
 			cmd := exec.Command("git", "diff", "HEAD~1")
 			cmd.Dir = dir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
-			if err != nil {
+			if cmd.Err != nil {
 				return err
 			}
 			err = cmd.Run()
@@ -436,10 +436,10 @@ func (r *Runner) interactive(dir string, repo scm.Repository) error {
 				return err
 			}
 		case 'r':
-			fmt.Println("Rejected, continuing...")
+			fmt.Fprintln(os.Stderr, "Rejected, continuing...")
 			return errRejected
 		case 'a':
-			fmt.Println("Accepted, proceeding...")
+			fmt.Fprintln(os.Stderr, "Accepted, proceeding...")
 			return nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	cmd.BuildDate, _ = time.ParseInLocation(time.RFC3339, date, time.UTC)
 	cmd.Commit = commit
 	if err := cmd.RootCmd().Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
These prints should have always been to stderr.

It opens up #441 to be implemented.