### PR TITLE
feat: Log stdout/err of cmdgit executions as Trace level

### DIFF
--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -48,12 +48,11 @@ func (g *Git) run(cmd *exec.Cmd) (string, error) {
 }
 
 func logGitExecution(cmd *exec.Cmd, stdout *bytes.Buffer, stderr *bytes.Buffer) {
-	logger := log.WithFields(log.Fields{
-		"cmd":    cmd,
+	log.WithFields(log.Fields{
+		"cmd":    cmd.String(),
 		"stdout": stdout.String(),
 		"stderr": stderr.String(),
-	})
-	logger.Trace("cmdgit")
+	}).Trace("cmdgit")
 }
 
 // Clone a repository

--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -30,6 +30,7 @@ func (g *Git) run(cmd *exec.Cmd) (string, error) {
 	cmd.Stdout = stdout
 
 	err := cmd.Run()
+	logGitExecution(cmd, stdout, stderr)
 	if err != nil {
 		matches := errRe.FindStringSubmatch(stderr.String())
 		if matches != nil {
@@ -44,6 +45,15 @@ func (g *Git) run(cmd *exec.Cmd) (string, error) {
 		return "", errors.New(msg)
 	}
 	return stdout.String(), nil
+}
+
+func logGitExecution(cmd *exec.Cmd, stdout *bytes.Buffer, stderr *bytes.Buffer) {
+	logger := log.WithFields(log.Fields{
+		"cmd":    cmd,
+		"stdout": stdout.String(),
+		"stderr": stderr.String(),
+	})
+	logger.Trace("cmdgit")
 }
 
 // Clone a repository


### PR DESCRIPTION
# What does this change
As discussed in #537, this adds the git standard output, and error streams in the trace log level, in order to troubleshoot git push failures (or other kind of git failures, that would be missed as not having this in trace level).

# What issue does it fix
Closes #537 

# Notes for the reviewer
 * I'm also including the git "cmd line", so it's clear what the output belongs to
   * _You'd mostly know that, as the output will be very familiar, but it makes sense to me to clarify this, if we're going to clarify this_
 * As we're logging 3 distinct things (the cmd line, stdout, and stderr), I thought it would make sense to add that via structured logging that's available (the `withFields`), to make the log more readable, and possible to filter more easily there, if needed.

# Checklist
- [X] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Tests if something new is added 
  -  _I haven't added any additional tests, as this is a very small contribution, and I haven't found logging to be covered with tests. If this is desired, I can add tests_
