### PR TITLE
feat: add api-push

### DIFF
--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -49,6 +49,8 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().IntP("concurrent", "C", 1, "The maximum number of concurrent runs.")
 	cmd.Flags().BoolP("skip-pr", "", false, "Skip pull request and directly push to the branch.")
 	cmd.Flags().BoolP("push-only", "", false, "Skip pull request and only push the feature branch.")
+	cmd.Flags().BoolP("api-push", "", false, `Push changes through the API instead of git. Only supported for GitHub.
+Has the benefit of automatically producing verified commits. But is slower and and suited for larger changes.`)
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
 	cmd.Flags().BoolP("interactive", "i", false, "Take manual decision before committing any change. Requires git to be installed.")
 	cmd.Flags().BoolP("dry-run", "d", false, "Run without pushing changes or creating pull requests.")
@@ -92,6 +94,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	concurrent, _ := flag.GetInt("concurrent")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
 	pushOnly, _ := flag.GetBool("push-only")
+	apiPush, _ := flag.GetBool("api-push")
 	skipRepository, _ := flag.GetStringSlice("skip-repo")
 	interactive, _ := flag.GetBool("interactive")
 	dryRun, _ := flag.GetBool("dry-run")
@@ -107,6 +110,9 @@ func run(cmd *cobra.Command, _ []string) error {
 	labels, _ := stringSlice(flag, "labels")
 	repoInclude, _ := flag.GetString("repo-include")
 	repoExclude, _ := flag.GetString("repo-exclude")
+
+	platform, _ := flag.GetString("platform")
+	gitType, _ := flag.GetString("git-type")
 
 	if concurrent < 1 {
 		return errors.New("concurrent runs can't be less than one")
@@ -147,6 +153,15 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	if concurrent > 1 && interactive {
 		return errors.New("--concurrent and --interactive can't be used at the same time")
+	}
+
+	if apiPush {
+		if platform != "github" {
+			return errors.New("api-push is only supported for GitHub")
+		}
+		if gitType != "go" {
+			return errors.New("api-push only works with go-git")
+		}
 	}
 
 	// Parse commit author data
@@ -241,6 +256,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		ForkOwner:              forkOwner,
 		SkipPullRequest:        skipPullRequest,
 		PushOnly:               pushOnly,
+		APIPush:                apiPush,
 		SkipRepository:         skipRepository,
 		CommitAuthor:           commitAuthor,
 		BaseBranch:             baseBranchName,

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -50,7 +50,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().BoolP("skip-pr", "", false, "Skip pull request and directly push to the branch.")
 	cmd.Flags().BoolP("push-only", "", false, "Skip pull request and only push the feature branch.")
 	cmd.Flags().BoolP("api-push", "", false, `Push changes through the API instead of git. Only supported for GitHub.
-Has the benefit of automatically producing verified commits. But is slower and and suited for larger changes.`)
+It has the benefit of automatically producing verified commits. However, it is slower and not suited for changes to large files.`)
 	cmd.Flags().StringSliceP("skip-repo", "s", nil, "Skip changes on specified repositories, the name is including the owner of repository in the format \"ownerName/repoName\".")
 	cmd.Flags().BoolP("interactive", "i", false, "Take manual decision before committing any change. Requires git to be installed.")
 	cmd.Flags().BoolP("dry-run", "d", false, "Run without pushing changes or creating pull requests.")

--- a/internal/git/changes.go
+++ b/internal/git/changes.go
@@ -1,0 +1,18 @@
+package git
+
+// Changes represents the changes made to a repository
+type Changes struct {
+	// Map of file paths to the changes made to the file
+	// The key is the file path and the value is the change
+	Additions map[string][]byte
+
+	// List of file paths that were deleted
+	Deletions []string
+
+	// OldHash is the hash of the previous commit
+	OldHash string
+}
+
+type LastCommitChecker interface {
+	LastCommitChanges() (Changes, error)
+}

--- a/internal/scm/changes.go
+++ b/internal/scm/changes.go
@@ -1,0 +1,20 @@
+package scm
+
+import (
+	"context"
+
+	"github.com/lindell/multi-gitter/internal/git"
+)
+
+// ChangePusher makes a commit through the API
+type ChangePusher interface {
+	Push(
+		ctx context.Context,
+		repo Repository,
+		commitMessage string,
+		change git.Changes,
+		featureBranch string,
+		branchExist bool,
+		forcePush bool,
+	) error
+}

--- a/internal/scm/github/commit.go
+++ b/internal/scm/github/commit.go
@@ -1,0 +1,230 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/lindell/multi-gitter/internal/git"
+	"github.com/lindell/multi-gitter/internal/scm"
+	"github.com/pkg/errors"
+)
+
+// Github should implement the ChangePusher interface
+var _ scm.ChangePusher = &Github{}
+
+func (g *Github) Push(
+	ctx context.Context,
+	r scm.Repository,
+	commitMessage string,
+	changes git.Changes,
+	featureBranch string,
+	branchExist bool,
+	forcePush bool,
+) error {
+	repo := r.(repository)
+
+	// There is no way to force push with the API, so we need to delete the branch
+	// and create it again.
+	if forcePush {
+		err := g.deleteRef(ctx, repo, featureBranch)
+		if err != nil {
+			return err
+		}
+
+		branchExist = false
+	}
+
+	if !branchExist {
+		err := g.CreateBranch(ctx, repo, featureBranch, changes.OldHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := g.CommitThroughAPI(ctx, repo, featureBranch, commitMessage, changes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Github) CommitThroughAPI(ctx context.Context,
+	repo repository,
+	branch string,
+	commitMessage string,
+	changes git.Changes,
+) error {
+	query := `
+		mutation ($input: CreateCommitOnBranchInput!) {
+			createCommitOnBranch(input: $input) {
+				commit {
+				url
+				}
+			}
+		}`
+
+	var v createCommitOnBranchInput
+
+	v.Input.Branch.RepositoryNameWithOwner = repo.ownerName + "/" + repo.name
+
+	v.Input.Branch.BranchName = branch
+	v.Input.ExpectedHeadOid = changes.OldHash
+	v.Input.Message.Headline = commitMessage
+
+	for path, contents := range changes.Additions {
+		v.Input.FileChanges.Additions = append(v.Input.FileChanges.Additions, commitAddition{
+			Path:     path,
+			Contents: base64.StdEncoding.EncodeToString(contents),
+		})
+	}
+
+	for _, path := range changes.Deletions {
+		v.Input.FileChanges.Deletions = append(v.Input.FileChanges.Deletions, commitDeletion{
+			Path: path,
+		})
+	}
+
+	var result map[string]interface{}
+
+	err := g.makeGraphQLRequest(ctx, query, v, &result)
+	if err != nil {
+		return errors.WithMessage(err, "could not commit changes though API")
+	}
+
+	return nil
+}
+
+func (g *Github) CreateBranch(ctx context.Context, repo repository, branchName string, oid string) error {
+	query := `mutation($input: CreateRefInput!){
+		createRef(input: $input) {
+			ref {
+				name
+			}
+		}
+	}`
+
+	if !strings.HasPrefix(repo.name, "refs/heads/") {
+		branchName = "refs/heads/" + branchName
+	}
+
+	var cri CreateRefInput
+	cri.Input.Name = branchName
+
+	cri.Input.Oid = oid
+	cri.Input.RepositoryID = repo.id
+
+	err := g.makeGraphQLRequest(ctx, query, cri, nil)
+	if err != nil {
+		return errors.WithMessage(err, "could not create branch")
+	}
+
+	return nil
+}
+
+func (g *Github) deleteRef(ctx context.Context, repo repository, branchName string) error {
+	branchRef, err := g.getBranchID(ctx, repo, branchName)
+	if err != nil {
+		return err
+	}
+
+	query := `mutation($input: DeleteRefInput!){
+		deleteRef(input: $input){
+			clientMutationId
+		}
+	}`
+
+	var deleteRefInput DeleteRefInput
+	deleteRefInput.Input.RefID = branchRef
+
+	err = g.makeGraphQLRequest(ctx, query, deleteRefInput, nil)
+	if err != nil {
+		return errors.WithMessage(err, "could not delete branch")
+	}
+
+	return nil
+}
+
+func (g *Github) getBranchID(ctx context.Context, repo repository, branchName string) (string, error) {
+	query := `query($owner: String!, $name: String!, $qualifiedName: String!) {
+		repository(owner: $owner, name: $name) {
+			ref(qualifiedName: $qualifiedName) {
+				id
+			}
+		}
+	}`
+
+	var result getRefOutput
+	err := g.makeGraphQLRequest(ctx, query, &RepositoryInput{
+		Name:          repo.name,
+		Owner:         repo.ownerName,
+		QualifiedName: fmt.Sprintf("refs/heads/%s", branchName),
+	}, &result)
+	if err != nil {
+		return "", errors.WithMessage(err, "could not get branch ID")
+	}
+
+	return result.Repository.Ref.ID, nil
+}
+
+type createCommitOnBranchInput struct {
+	Input struct {
+		ExpectedHeadOid string `json:"expectedHeadOid"`
+		Branch          struct {
+			RepositoryNameWithOwner string `json:"repositoryNameWithOwner"`
+			BranchName              string `json:"branchName"`
+		} `json:"branch"`
+		Message struct {
+			Headline string `json:"headline"`
+		} `json:"message"`
+		FileChanges struct {
+			Additions []commitAddition `json:"additions"`
+			Deletions []commitDeletion `json:"deletions"`
+		} `json:"fileChanges"`
+	} `json:"input"`
+}
+
+type commitAddition struct {
+	Path     string `json:"path,omitempty"`
+	Contents string `json:"contents,omitempty"`
+}
+
+type commitDeletion struct {
+	Path string `json:"path,omitempty"`
+}
+
+type CreateRefInput struct {
+	Input struct {
+		Name         string `json:"name"`
+		Oid          string `json:"oid"`
+		RepositoryID string `json:"repositoryId"`
+	} `json:"input"`
+}
+
+type RepositoryInput struct {
+	Name          string `json:"name"`
+	Owner         string `json:"owner"`
+	QualifiedName string `json:"qualifiedName"`
+}
+
+type DeleteRefInput struct {
+	Input struct {
+		RefID string `json:"refId"`
+	} `json:"input"`
+}
+
+type getRepositoryOutput struct {
+	Repository struct {
+		ID string `json:"id"`
+	} `json:"repository"`
+}
+
+type getRefOutput struct {
+	Repository struct {
+		Ref struct {
+			ID string `json:"id"`
+		} `json:"ref"`
+	} `json:"repository"`
+}

--- a/internal/scm/github/graphql.go
+++ b/internal/scm/github/graphql.go
@@ -84,6 +84,10 @@ func (g *Github) makeGraphQLRequest(ctx context.Context, query string, data inte
 		return errors.Errorf("could not make GitHub GraphQL request: %s", resultData.Message)
 	}
 
+	if res == nil {
+		return nil
+	}
+
 	if err := json.Unmarshal(resultData.Data, res); err != nil {
 		return errors.WithMessage(err, "could not unmarshal graphQL result")
 	}

--- a/internal/scm/github/repository.go
+++ b/internal/scm/github/repository.go
@@ -24,6 +24,7 @@ func (g *Github) convertRepo(r *github.Repository) (repository, error) {
 
 	return repository{
 		url:           repoURL,
+		id:            r.GetNodeID(),
 		name:          r.GetName(),
 		ownerName:     r.GetOwner().GetLogin(),
 		defaultBranch: r.GetDefaultBranch(),
@@ -32,6 +33,7 @@ func (g *Github) convertRepo(r *github.Repository) (repository, error) {
 
 type repository struct {
 	url           string
+	id            string
 	name          string
 	ownerName     string
 	defaultBranch string

--- a/tests/vcmock/vcmock.go
+++ b/tests/vcmock/vcmock.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	git "github.com/go-git/go-git/v5"
+	internalgit "github.com/lindell/multi-gitter/internal/git"
 	"github.com/lindell/multi-gitter/internal/scm"
 	"github.com/pkg/errors"
 )
@@ -19,6 +20,7 @@ type VersionController struct {
 	PRNumber     int
 	Repositories []Repository
 	PullRequests []PullRequest
+	Changes      []internalgit.Changes
 
 	prLock sync.RWMutex
 }
@@ -150,6 +152,20 @@ func (vc *VersionController) SetPRStatus(repoName string, branchName string, new
 			vc.PullRequests[i].PRStatus = newStatus
 		}
 	}
+}
+
+func (vc *VersionController) Push(
+	ctx context.Context,
+	r scm.Repository,
+	commitMessage string,
+	changes internalgit.Changes,
+	featureBranch string,
+	branchExist bool,
+	forcePush bool,
+) error {
+	vc.Changes = append(vc.Changes, changes)
+
+	return nil
 }
 
 // GetAutocompleteOrganizations gets organizations for autocompletion


### PR DESCRIPTION
Based on #492

Push changes through the API instead of git. Only supported for GitHub.
It has the benefit of automatically producing verified commits. However, it is slower and not suited for changes to large files.