### PR TITLE
adding bearer token fix for deleting a branch from bitbucket server

### DIFF
--- a/internal/scm/bitbucketserver/bitbucket_server.go
+++ b/internal/scm/bitbucketserver/bitbucket_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -519,7 +518,7 @@ func (b *BitbucketServer) deleteBranch(ctx context.Context, pr pullRequest) erro
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add(
 		"Authorization",
-		"Basic "+base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", b.username, b.token))),
+		"Bearer "+b.token,
 	)
 
 	response, err := b.httpClient.Do(request)


### PR DESCRIPTION
# What does this change
Switches delete to use a bearer token as the API expects in this case

_For example if it introduces a new flag or modifies a commands output, give an example of you running the command and showing real output here._

# What issue does it fix
Closes #482

_If there is not an existing issue, please make sure we have context on why this change is needed. ._

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added
- [ ] Integration testing
