### PR TITLE
fix: use space instead of '+' as Gerrit query parameter separator

### DIFF
--- a/internal/scm/gerrit/gerrit.go
+++ b/internal/scm/gerrit/gerrit.go
@@ -302,7 +302,7 @@ func (g Gerrit) queryChanges(ctx context.Context, branchName string, filters []s
 	defaultFilters := []string{
 		"footer:" + FooterBranch + "=" + branchName,
 	}
-	query := strings.Join(append(defaultFilters, filters...), "+")
+	query := strings.Join(append(defaultFilters, filters...), " ")
 
 	opt := &gogerrit.QueryChangeOptions{
 		QueryOptions: gogerrit.QueryOptions{

--- a/internal/scm/gerrit/gerrit_test.go
+++ b/internal/scm/gerrit/gerrit_test.go
@@ -71,7 +71,7 @@ var projects = &map[string]gogerrit.ProjectInfo{
 
 func getChangesForQuery(query string) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
 	var data = map[string][]gogerrit.ChangeInfo{
-		"footer:MultiGitter-Branch=feature+project:repo-active+is:open": {
+		"footer:MultiGitter-Branch=feature project:repo-active is:open": {
 			{Project: "repo-active", ChangeID: "I123", Branch: "feature", Number: 1000, Status: "NEW"},
 		},
 		"footer:MultiGitter-Branch=feature": {
@@ -81,8 +81,8 @@ func getChangesForQuery(query string) (*[]gogerrit.ChangeInfo, *gogerrit.Respons
 			{Project: "another-repo-active", ChangeID: "I666", Branch: "feature", Number: 1003, Status: "MERGED"},
 			{Project: "name-that-do-not-match", ChangeID: "I000", Branch: "feature", Number: 1004, Submittable: true},
 		},
-		"footer:MultiGitter-Branch=feature+project:another-repo-active+is:open": {},
-		"footer:MultiGitter-Branch=feature+project:read-only+is:open": {
+		"footer:MultiGitter-Branch=feature project:another-repo-active is:open": {},
+		"footer:MultiGitter-Branch=feature project:read-only is:open": {
 			{Project: "read-only", ChangeID: "I456", Branch: "feature", Number: 1004, Status: "NEW"},
 			{Project: "read-only", ChangeID: "I789", Branch: "feature", Number: 1004, Status: "NEW"},
 		},


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                  
- Fixes a regression introduced in v0.62.0 by the automated dependency bump of `go-gerrit` to v1.1.1 (commit b9161da)                                                                                                                       
- `go-gerrit` v1.1.1 changed how `+` is handled in query strings — it is no longer treated as a parameter separator but as a literal character (see [andygrunwald/go-gerrit#193](https://github.com/andygrunwald/go-gerrit/pull/193))       
- Replaces `+` with a space (` `) as the Gerrit query term separator, which is the canonical separator per the [Gerrit query syntax](https://gerrit-review.googlesource.com/Documentation/user-search.html)                                 
                                                                                                                                                                                                                                              
## Root cause                                                                                                                                                                                                                               
 `queryChanges` was joining query predicates with `+` (e.g. `footer:MultiGitter-Branch=feature+project:repo-active+is:open`). Prior to `go-gerrit` v1.1.1, the library URL-encoded this string and `+` was interpreted server-side as a space.
Starting with v1.1.1, `+` is passed through as-is and Gerrit no longer recognises it as a separator, causing multi-predicate queries to return no results.                                                                           
                                                                                                                                                                                                                                              
## Fix                                                                                                                                                                                                                                      
Replace the `"+"` join separator with `" "` in `internal/scm/gerrit/gerrit.go`. The `go-gerrit` library properly percent-encodes the space as `%20` when building the request URL, which Gerrit interprets correctly.                       
                                                                                                                                                                                                                                              
Update the corresponding test fixtures in `gerrit_test.go` to reflect the new expected query format.                                                                                                                                        
                                                                                                                                                                                                                                              
## Test plan                                                                                                                                                                                                                                                           
- [X] Existing unit tests updated and passing                                                                                                                                                                                               
- [X] Manual test against a Gerrit instance with a multi-predicate query  