### PR TITLE
feat: add --sleep-between-batch flag to prevent build storms (#481)

### DIFF
--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -46,6 +46,7 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().IntP("max-reviewers", "M", 0, "If this value is set, reviewers will be randomized.")
 	cmd.Flags().IntP("max-team-reviewers", "", 0, "If this value is set, team reviewers will be randomized")
 	cmd.Flags().IntP("concurrent", "C", 1, "The maximum number of concurrent runs.")
+	cmd.Flags().DurationP("sleep-between-batch", "", 0, "Sleep duration between concurrent batches (e.g., 30s, 1m).")
 	cmd.Flags().BoolP("skip-pr", "", false, "Skip pull request and directly push to the branch.")
 	cmd.Flags().BoolP("push-only", "", false, "Skip pull request and only push the feature branch.")
 	cmd.Flags().BoolP("manual-commit", "", false, "Let the script commit the changes, multiple commits are allowed, multi-gitter will still open a pull request when changes are detected.")
@@ -93,6 +94,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	maxReviewers, _ := flag.GetInt("max-reviewers")
 	maxTeamReviewers, _ := flag.GetInt("max-team-reviewers")
 	concurrent, _ := flag.GetInt("concurrent")
+	sleepBetweenBatch, _ := flag.GetDuration("sleep-between-batch")
 	skipPullRequest, _ := flag.GetBool("skip-pr")
 	pushOnly, _ := flag.GetBool("push-only")
 	manualCommit, _ := flag.GetBool("manual-commit")
@@ -249,10 +251,11 @@ func run(cmd *cobra.Command, _ []string) error {
 		ConflictStrategy: conflictStrategy,
 		Draft:            draft,
 		AutoMerge:        prAutoMerge,
-		Labels:           labels,
-		CloneDir:         cloneDir,
+		Labels:            labels,
+		CloneDir:          cloneDir,
 
-		Concurrent: concurrent,
+		Concurrent:        concurrent,
+		SleepBetweenBatch: sleepBetweenBatch,
 
 		CreateGit: gitCreator,
 	}

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -251,8 +251,8 @@ func run(cmd *cobra.Command, _ []string) error {
 		ConflictStrategy: conflictStrategy,
 		Draft:            draft,
 		AutoMerge:        prAutoMerge,
-		Labels:   labels,
-		CloneDir: cloneDir,
+		Labels:           labels,
+		CloneDir:         cloneDir,
 
 		Concurrent:        concurrent,
 		SleepBetweenBatch: sleepBetweenBatch,

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -251,8 +251,8 @@ func run(cmd *cobra.Command, _ []string) error {
 		ConflictStrategy: conflictStrategy,
 		Draft:            draft,
 		AutoMerge:        prAutoMerge,
-		Labels:            labels,
-		CloneDir:          cloneDir,
+		Labels:   labels,
+		CloneDir: cloneDir,
 
 		Concurrent:        concurrent,
 		SleepBetweenBatch: sleepBetweenBatch,

--- a/internal/multigitter/print.go
+++ b/internal/multigitter/print.go
@@ -65,7 +65,7 @@ func (r Printer) Print(ctx context.Context) error {
 		}
 
 		rc.AddSuccessRepositories(repos[i])
-	}, len(repos), r.Concurrent)
+	}, len(repos), r.Concurrent, 0)
 
 	return nil
 }

--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unicode"
 
 	"github.com/eiannone/keyboard"
@@ -69,12 +70,13 @@ type Runner struct {
 	BaseBranch       string // The base branch of the PR, use default branch if not set
 	Assignees        []string
 
-	Concurrent      int
-	SkipPullRequest bool     // If set, the script will run directly on the base-branch without creating any PR
-	PushOnly        bool     // If set, the script will only publish the feature branch without creating a PR
-	APIPush         bool     // Use the SCM API to commit and push the changes instead of git
-	PushOptions     []string // Options to pass to git push command
-	ManualCommit    bool     // If set, multi-gitter will not commit the changes left by the script.
+	Concurrent         int
+	SleepBetweenBatch  time.Duration // Sleep duration between concurrent batches
+	SkipPullRequest    bool          // If set, the script will run directly on the base-branch without creating any PR
+	PushOnly           bool          // If set, the script will only publish the feature branch without creating a PR
+	APIPush            bool          // Use the SCM API to commit and push the changes instead of git
+	PushOptions        []string      // Options to pass to git push command
+	ManualCommit       bool          // If set, multi-gitter will not commit the changes left by the script.
 
 	// RepoFilters contains repository filtering options
 	RepoFilters RepoFilters
@@ -172,16 +174,27 @@ func (r *Runner) Run(ctx context.Context) error {
 		} else {
 			rc.AddSuccessRepositories(repos[i])
 		}
-	}, len(repos), r.Concurrent)
+	}, len(repos), r.Concurrent, r.SleepBetweenBatch)
 
 	return nil
 }
 
-func runInParallel(fun func(i int), total int, maxConcurrent int) {
+func runInParallel(fun func(i int), total int, maxConcurrent int, sleepBetweenBatch time.Duration) {
 	concurrentGoroutines := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
-	wg.Add(total)
+
 	for i := 0; i < total; i++ {
+		// If we need to sleep between batches and we're starting a new batch (not the first)
+		if sleepBetweenBatch > 0 && i > 0 && i%maxConcurrent == 0 {
+			// Wait for the previous batch to complete before sleeping
+			wg.Wait()
+			log.Infof("Sleeping for %v before starting next batch", sleepBetweenBatch)
+			time.Sleep(sleepBetweenBatch)
+			// Reset wait group for the next batch
+			wg = sync.WaitGroup{}
+		}
+
+		wg.Add(1)
 		concurrentGoroutines <- struct{}{}
 		go func(i int) {
 			defer wg.Done()

--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -180,27 +180,52 @@ func (r *Runner) Run(ctx context.Context) error {
 }
 
 func runInParallel(fun func(i int), total int, maxConcurrent int, sleepBetweenBatch time.Duration) {
+	if sleepBetweenBatch == 0 {
+		// Fast path: no sleep, use simple semaphore pattern
+		concurrentGoroutines := make(chan struct{}, maxConcurrent)
+		var wg sync.WaitGroup
+		wg.Add(total)
+		for i := 0; i < total; i++ {
+			concurrentGoroutines <- struct{}{}
+			go func(i int) {
+				defer wg.Done()
+				fun(i)
+				<-concurrentGoroutines
+			}(i)
+		}
+		wg.Wait()
+		return
+	}
+
+	// Slow path: sleep between batches
 	concurrentGoroutines := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
+	wg.Add(total)
 
-	for i := 0; i < total; i++ {
-		// If we need to sleep between batches and we're starting a new batch (not the first)
-		if sleepBetweenBatch > 0 && i > 0 && i%maxConcurrent == 0 {
-			// Wait for the previous batch to complete before sleeping
-			wg.Wait()
+	for batchStart := 0; batchStart < total; batchStart += maxConcurrent {
+		if batchStart > 0 && sleepBetweenBatch > 0 {
 			log.Infof("Sleeping for %v before starting next batch", sleepBetweenBatch)
 			time.Sleep(sleepBetweenBatch)
-			// Reset wait group for the next batch
-			wg = sync.WaitGroup{}
 		}
 
-		wg.Add(1)
-		concurrentGoroutines <- struct{}{}
-		go func(i int) {
-			defer wg.Done()
-			fun(i)
-			<-concurrentGoroutines
-		}(i)
+		batchEnd := batchStart + maxConcurrent
+		if batchEnd > total {
+			batchEnd = total
+		}
+
+		var batchWg sync.WaitGroup
+		for i := batchStart; i < batchEnd; i++ {
+			batchWg.Add(1)
+			concurrentGoroutines <- struct{}{}
+			go func(i int) {
+				defer wg.Done()
+				defer batchWg.Done()
+				fun(i)
+				<-concurrentGoroutines
+			}(i)
+		}
+		// Wait for this batch to complete before starting the next
+		batchWg.Wait()
 	}
 	wg.Wait()
 }

--- a/internal/multigitter/run_test.go
+++ b/internal/multigitter/run_test.go
@@ -1,0 +1,98 @@
+package multigitter
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunInParallel_NoSleep(t *testing.T) {
+	start := time.Now()
+	count := 0
+	var mu sync.Mutex
+
+	runInParallel(func(i int) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}, 10, 5, 0)
+
+	elapsed := time.Since(start)
+	if count != 10 {
+		t.Errorf("Expected 10 executions, got %d", count)
+	}
+	// Should complete in roughly 20ms (2 batches * 10ms)
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Took too long without sleep: %v", elapsed)
+	}
+}
+
+func TestRunInParallel_WithSleep(t *testing.T) {
+	start := time.Now()
+	count := 0
+	var mu sync.Mutex
+	sleepDuration := 50 * time.Millisecond
+
+	runInParallel(func(i int) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}, 10, 5, sleepDuration)
+
+	elapsed := time.Since(start)
+	if count != 10 {
+		t.Errorf("Expected 10 executions, got %d", count)
+	}
+	// Should sleep once between the two batches (5+5)
+	// Total: ~20ms execution + 50ms sleep = 70ms minimum
+	if elapsed < sleepDuration {
+		t.Errorf("Should have slept at least %v, but took %v", sleepDuration, elapsed)
+	}
+}
+
+func TestRunInParallel_SingleBatch(t *testing.T) {
+	start := time.Now()
+	sleepDuration := 50 * time.Millisecond
+
+	runInParallel(func(i int) {
+		time.Sleep(10 * time.Millisecond)
+	}, 5, 10, sleepDuration)
+
+	elapsed := time.Since(start)
+	// Single batch, no sleep should occur
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Should not have slept for single batch, took %v", elapsed)
+	}
+}
+
+func TestRunInParallel_MultipleBatches(t *testing.T) {
+	batches := make([][]int, 0)
+	var mu sync.Mutex
+	currentBatch := make([]int, 0)
+	sleepDuration := 30 * time.Millisecond
+
+	runInParallel(func(i int) {
+		mu.Lock()
+		currentBatch = append(currentBatch, i)
+		if len(currentBatch) == 3 {
+			batches = append(batches, currentBatch)
+			currentBatch = make([]int, 0)
+		}
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}, 9, 3, sleepDuration)
+
+	// Flush remaining
+	mu.Lock()
+	if len(currentBatch) > 0 {
+		batches = append(batches, currentBatch)
+	}
+	mu.Unlock()
+
+	// Should have 3 batches
+	if len(batches) != 3 {
+		t.Errorf("Expected 3 batches, got %d", len(batches))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--sleep-between-batch` flag (e.g. `--sleep-between-batch 30s`) that inserts a configurable delay between concurrent batches
- When the flag is not set (default `0`), the existing semaphore-based concurrency behavior is unchanged
- When set, `runInParallel` switches to batch mode: process `--concurrent` repos, wait for them to finish, sleep, then start the next batch

This prevents CI/CD build storms when multi-gitter pushes to many repos at once.

Fixes #481

## Test plan

- `go test ./...` all green
- `go vet` clean, race detector clean
- 4 new tests: no-sleep path, with-sleep timing, single-batch (no sleep triggered), multiple-batch ordering
- All existing call sites updated (`Printer.Print` passes `0` for sleep duration)
<!-- sweep:amend:attestation -->
[Failing tests before](https://github.com/kimjune01/sweep/blob/76f896df293c79f11ae813cdf8d699c93b8406eb/attestations/lindell-multi-gitter/issue-620-before.txt) / [Passing tests after](https://github.com/kimjune01/sweep/blob/76f896df293c79f11ae813cdf8d699c93b8406eb/attestations/lindell-multi-gitter/issue-620-after.txt) / [How the tests ran](https://github.com/kimjune01/sweep/blob/76f896df293c79f11ae813cdf8d699c93b8406eb/attestations/lindell-multi-gitter/issue-620-manifest.json)
<!-- /sweep:amend:attestation -->

<!-- sweep:compose -->
_Sweep attestation `5e95dce4e609` — see the receipts footer below._
<!-- /sweep:compose -->




