### PR TITLE
Link to GUI web URL of branch in --push-only mode

### DIFF
--- a/internal/multigitter/run.go
+++ b/internal/multigitter/run.go
@@ -106,6 +106,7 @@ var (
 type dryRunPullRequest struct {
 	status     scm.PullRequestStatus
 	Repository scm.Repository
+	branchName string
 }
 
 func (pr dryRunPullRequest) Status() scm.PullRequestStatus {
@@ -114,6 +115,14 @@ func (pr dryRunPullRequest) Status() scm.PullRequestStatus {
 
 func (pr dryRunPullRequest) String() string {
 	return fmt.Sprintf("%s #0", pr.Repository.FullName())
+}
+
+func (pr dryRunPullRequest) URL() string {
+	if pr.branchName == "" {
+		return ""
+	}
+
+	return pr.Repository.BranchURL(pr.branchName)
 }
 
 // Run runs a script for multiple repositories and creates PRs with the changes made
@@ -366,6 +375,7 @@ func (r *Runner) runSingleRepo(ctx context.Context, repo scm.Repository) (scm.Pu
 	if r.PushOnly {
 		return dryRunPullRequest{
 			Repository: repo,
+			branchName: r.FeatureBranch,
 		}, nil
 	}
 

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -383,7 +383,16 @@ func (bbc *BitbucketCloud) convertRepository(repo bitbucket.Repository) (*reposi
 		project:       repo.Project.Name,
 		defaultBranch: repo.Mainbranch.Name,
 		cloneURL:      cloneURL,
+		webURL:        firstHref(rLinks.HTML),
 	}, nil
+}
+
+func firstHref(links []hrefLink) string {
+	if len(links) == 0 {
+		return ""
+	}
+
+	return links[0].Href
 }
 
 func findLinkType(cloneLinks []hrefLink, cloneType string, repoName string) (string, error) {

--- a/internal/scm/bitbucketcloud/custom_structs.go
+++ b/internal/scm/bitbucketcloud/custom_structs.go
@@ -105,6 +105,11 @@ func (r repository) CloneURL() string {
 	return r.cloneURL
 }
 
+func (r repository) BranchURL(branchName string) string {
+	// Not yet implemented
+	return ""
+}
+
 func (r repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/internal/scm/bitbucketcloud/custom_structs.go
+++ b/internal/scm/bitbucketcloud/custom_structs.go
@@ -2,6 +2,7 @@ package bitbucketcloud
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/lindell/multi-gitter/internal/scm"
@@ -99,6 +100,7 @@ type repository struct {
 	project       string
 	defaultBranch string
 	cloneURL      string
+	webURL        string
 }
 
 func (r repository) CloneURL() string {
@@ -106,8 +108,11 @@ func (r repository) CloneURL() string {
 }
 
 func (r repository) BranchURL(branchName string) string {
-	// Not yet implemented
-	return ""
+	if r.webURL == "" {
+		return ""
+	}
+
+	return r.webURL + "/branch/" + url.PathEscape(branchName)
 }
 
 func (r repository) DefaultBranch() string {

--- a/internal/scm/bitbucketserver/repository.go
+++ b/internal/scm/bitbucketserver/repository.go
@@ -62,6 +62,11 @@ func (r repository) CloneURL() string {
 	return r.cloneURL
 }
 
+func (r repository) BranchURL(branchName string) string {
+	// Not yet implemented
+	return ""
+}
+
 func (r repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/internal/scm/bitbucketserver/repository.go
+++ b/internal/scm/bitbucketserver/repository.go
@@ -2,6 +2,7 @@ package bitbucketserver
 
 import (
 	"net/url"
+	"path"
 	"strings"
 
 	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
@@ -35,6 +36,7 @@ func (b *BitbucketServer) convertRepository(bitbucketRepository *bitbucketv1.Rep
 		project:       bitbucketRepository.Project.Key,
 		defaultBranch: defaultBranch.DisplayID,
 		cloneURL:      cloneURL,
+		webURL:        b.repositoryWebURL(bitbucketRepository.Project.Key, bitbucketRepository.Slug),
 	}
 
 	return &repo, nil
@@ -56,6 +58,7 @@ type repository struct {
 	project       string
 	defaultBranch string
 	cloneURL      string
+	webURL        string
 }
 
 func (r repository) CloneURL() string {
@@ -63,8 +66,11 @@ func (r repository) CloneURL() string {
 }
 
 func (r repository) BranchURL(branchName string) string {
-	// Not yet implemented
-	return ""
+	if r.webURL == "" {
+		return ""
+	}
+
+	return r.webURL + "/browse?at=" + url.QueryEscape("refs/heads/"+branchName)
 }
 
 func (r repository) DefaultBranch() string {
@@ -73,4 +79,19 @@ func (r repository) DefaultBranch() string {
 
 func (r repository) FullName() string {
 	return r.project + "/" + r.name
+}
+
+func (b *BitbucketServer) repositoryWebURL(projectKey, slug string) string {
+	if b.baseURL == nil {
+		return ""
+	}
+
+	browserURL := *b.baseURL
+	browserURL.Path = strings.TrimSuffix(browserURL.Path, "/rest")
+	browserURL.Path = path.Join(browserURL.Path, "projects", projectKey, "repos", slug)
+	browserURL.RawPath = ""
+	browserURL.RawQuery = ""
+	browserURL.Fragment = ""
+
+	return browserURL.String()
 }

--- a/internal/scm/gerrit/gerrit.go
+++ b/internal/scm/gerrit/gerrit.go
@@ -177,6 +177,7 @@ func (g Gerrit) convertRepo(ctx context.Context, name string) (repository, error
 
 	return repository{
 		url:           repoURL,
+		webURL:        strings.TrimSuffix(g.config.BaseURL, "/") + "/admin/repos/" + name,
 		name:          name,
 		defaultBranch: defaultBranch,
 	}, nil

--- a/internal/scm/gerrit/repository.go
+++ b/internal/scm/gerrit/repository.go
@@ -10,6 +10,11 @@ func (r repository) CloneURL() string {
 	return r.url
 }
 
+func (r repository) BranchURL(branchName string) string {
+	// Not yet implemented
+	return ""
+}
+
 func (r repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/internal/scm/gerrit/repository.go
+++ b/internal/scm/gerrit/repository.go
@@ -1,7 +1,10 @@
 package gerrit
 
+import "fmt"
+
 type repository struct {
 	url           string
+	webURL        string
 	name          string
 	defaultBranch string
 }
@@ -10,9 +13,12 @@ func (r repository) CloneURL() string {
 	return r.url
 }
 
-func (r repository) BranchURL(branchName string) string {
-	// Not yet implemented
-	return ""
+func (r repository) BranchURL(_ string) string {
+	if r.webURL == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s,+branches", r.webURL)
 }
 
 func (r repository) DefaultBranch() string {

--- a/internal/scm/gitea/repository.go
+++ b/internal/scm/gitea/repository.go
@@ -23,6 +23,7 @@ func (g *Gitea) convertRepository(repo *gitea.Repository) (repository, error) {
 
 	return repository{
 		url:           repoURL,
+		webURL:        repo.HTMLURL,
 		name:          repo.Name,
 		ownerName:     repo.Owner.UserName,
 		defaultBranch: repo.DefaultBranch,
@@ -31,6 +32,7 @@ func (g *Gitea) convertRepository(repo *gitea.Repository) (repository, error) {
 
 type repository struct {
 	url           string
+	webURL        string
 	name          string
 	ownerName     string
 	defaultBranch string
@@ -41,8 +43,11 @@ func (r repository) CloneURL() string {
 }
 
 func (r repository) BranchURL(branchName string) string {
-	// Not yet implemented
-	return ""
+	if r.webURL == "" {
+		return ""
+	}
+
+	return r.webURL + "/src/branch/" + url.PathEscape(branchName)
 }
 
 func (r repository) DefaultBranch() string {

--- a/internal/scm/gitea/repository.go
+++ b/internal/scm/gitea/repository.go
@@ -40,6 +40,11 @@ func (r repository) CloneURL() string {
 	return r.url
 }
 
+func (r repository) BranchURL(branchName string) string {
+	// Not yet implemented
+	return ""
+}
+
 func (r repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/internal/scm/github/repository.go
+++ b/internal/scm/github/repository.go
@@ -24,6 +24,7 @@ func (g *Github) convertRepo(r *github.Repository) (repository, error) {
 
 	return repository{
 		url:           repoURL,
+		webURL:        r.GetHTMLURL(),
 		id:            r.GetNodeID(),
 		name:          r.GetName(),
 		ownerName:     r.GetOwner().GetLogin(),
@@ -33,6 +34,7 @@ func (g *Github) convertRepo(r *github.Repository) (repository, error) {
 
 type repository struct {
 	url           string
+	webURL        string
 	id            string
 	name          string
 	ownerName     string
@@ -41,6 +43,14 @@ type repository struct {
 
 func (r repository) CloneURL() string {
 	return r.url
+}
+
+func (r repository) BranchURL(branchName string) string {
+	if r.webURL == "" {
+		return ""
+	}
+
+	return r.webURL + "/tree/" + url.PathEscape(branchName)
 }
 
 func (r repository) DefaultBranch() string {

--- a/internal/scm/gitlab/repository.go
+++ b/internal/scm/gitlab/repository.go
@@ -54,6 +54,11 @@ func (r repository) CloneURL() string {
 	return r.url
 }
 
+func (r repository) BranchURL(branchName string) string {
+	// Not yet implemented
+	return ""
+}
+
 func (r repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/internal/scm/gitlab/repository.go
+++ b/internal/scm/gitlab/repository.go
@@ -22,6 +22,7 @@ func (g *Gitlab) convertProject(project *gitlab.Project) (repository, error) {
 
 	return repository{
 		url:           cloneURL,
+		webURL:        project.WebURL,
 		pid:           project.ID,
 		name:          project.Path,
 		ownerName:     project.Namespace.FullPath,
@@ -43,6 +44,7 @@ func shouldSquash(project *gitlab.Project) bool {
 
 type repository struct {
 	url           string
+	webURL        string
 	pid           int64
 	name          string
 	ownerName     string
@@ -55,8 +57,11 @@ func (r repository) CloneURL() string {
 }
 
 func (r repository) BranchURL(branchName string) string {
-	// Not yet implemented
-	return ""
+	if r.webURL == "" {
+		return ""
+	}
+
+	return r.webURL + "/-/tree/" + url.PathEscape(branchName)
 }
 
 func (r repository) DefaultBranch() string {

--- a/internal/scm/repository.go
+++ b/internal/scm/repository.go
@@ -4,6 +4,8 @@ package scm
 type Repository interface {
 	// CloneURL returns the clone address of the repository
 	CloneURL() string
+	// BranchURL returns a browser URL for the named branch when available
+	BranchURL(branchName string) string
 	// DefaultBranch returns the name of the default branch of the repository
 	DefaultBranch() string
 	// FullName returns the full id of the repository, usually ownerName/repoName

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lindell/multi-gitter/cmd"
 	"github.com/lindell/multi-gitter/internal/multigitter"
+	"github.com/lindell/multi-gitter/internal/multigitter/terminal"
 	"github.com/lindell/multi-gitter/internal/scm"
 	"github.com/lindell/multi-gitter/tests/vcmock"
 
@@ -1386,7 +1387,7 @@ Repositories with a successful run:
 			},
 			verify: func(t *testing.T, vcMock *vcmock.VersionController, runData runData) {
 				assert.Equal(t, "", runData.cmdOut)
-				assert.Equal(t, "Repositories with a successful run:\n  owner/example-repository #0\n", runData.out)
+				assert.Equal(t, "Repositories with a successful run:\n  "+terminal.Link("owner/example-repository #0", "https://github.com/owner/example-repository/tree/custom-branch-name")+"\n", runData.out)
 			},
 		},
 		{

--- a/tests/vcmock/vcmock.go
+++ b/tests/vcmock/vcmock.go
@@ -5,6 +5,7 @@ package vcmock
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -255,6 +256,10 @@ type Repository struct {
 // CloneURL return the URL (filepath) of the repository on disk
 func (r Repository) CloneURL() string {
 	return fmt.Sprintf(`file://%s`, filepath.ToSlash(r.Path))
+}
+
+func (r Repository) BranchURL(branchName string) string {
+	return fmt.Sprintf("https://github.com/%s/%s/tree/%s", r.OwnerName, r.RepoName, url.PathEscape(branchName))
 }
 
 // DefaultBranch returns "master"


### PR DESCRIPTION
# What does this change

When using `run` with `--push-only` mode, the `Repositories with a successful run:` list entries (printed out right at the end) are now terminal hyperlinks to the GUI web URL of the branch, e.g. https://github.com/ORG/REPO/tree/BRANCH

This makes it easier for the user to review what was pushed & then most SCM managers will show a button, on that branch page, allowing you to create a PR from that branch.

# What issue does it fix
Closes #555

# Notes for the reviewer
- The 1st commit is tested and working with GitHub.
- The 2nd commit is rather speculative but I have not been able to verify it with those providers - if you would prefer I can remove this and just add support for GitHub initially, allowing others to add support for other platforms which they can test.
- Without the 2nd commit, other SCM managers should be unaffected because the string-ification [calls URL()](https://github.com/lindell/multi-gitter/blob/55cdf48a8dde6af650f8f4ee975c9d812688a4b1/internal/multigitter/repocounter/counter.go#L30) and checks for the empty string, which is what `URL` will return via `BranchURL` (in the stub implementations in the first commit) so it should just continue to display the repo name as before.

# Checklist
- [x] Made sure the PR follows the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Tests if something new is added (well, existing test is updated to cover it)
